### PR TITLE
[ADD]: #22 - gray4 컬러 에셋 추가

### DIFF
--- a/DooRiBon/DooRiBon/Resources/Colors.xcassets/gray4.colorset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Colors.xcassets/gray4.colorset/Contents.json
@@ -5,27 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
-        }
-      },
-      "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.420",
+          "green" : "0.396",
+          "red" : "0.369"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## 🌴 PR 요약
작업 도중 gray4의 컬러값이 누락되어 있어 추가하였습니다.

🌱 작업한 브랜치
- feature/22-add-missed-color

🌱 작업한 내용
- 누락된 컬러 gray4 에셋 추가

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|컬러추가| <img width="115" alt="스크린샷 2021-07-03 오후 3 43 34" src="https://user-images.githubusercontent.com/61109660/124345708-762cbf00-dc15-11eb-8790-a948507d425b.png">|

## 📮 관련 이슈
- Resolved: #22 