### PR TITLE
[FEAT] #15 - 탭 바 세팅 및 연결

### DIFF
--- a/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
+++ b/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
@@ -17,6 +17,16 @@
 		40AE782E268F81E20058806B /* PhotoCollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AE782D268F81E20058806B /* PhotoCollectionViewModel.swift */; };
 		40B5A090268EE2E500A89875 /* AddTripStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 40B5A08F268EE2E500A89875 /* AddTripStoryboard.storyboard */; };
 		40B5A092268EE35100A89875 /* AddTripViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B5A091268EE35100A89875 /* AddTripViewController.swift */; };
+		BD0AD60E269361D50033DAD8 /* TripStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD0AD60D269361D50033DAD8 /* TripStoryboard.storyboard */; };
+		BD0AD616269363D10033DAD8 /* MemberStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD0AD615269363D10033DAD8 /* MemberStoryboard.storyboard */; };
+		BD0AD618269363D90033DAD8 /* PlanStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD0AD617269363D90033DAD8 /* PlanStoryboard.storyboard */; };
+		BD0AD61A269363E30033DAD8 /* BoardStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD0AD619269363E30033DAD8 /* BoardStoryboard.storyboard */; };
+		BD0AD61C269363ED0033DAD8 /* StoreStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD0AD61B269363ED0033DAD8 /* StoreStoryboard.storyboard */; };
+		BD0AD61E269364D90033DAD8 /* MemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AD61D269364D90033DAD8 /* MemberViewController.swift */; };
+		BD0AD620269365050033DAD8 /* PlanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AD61F269365050033DAD8 /* PlanViewController.swift */; };
+		BD0AD6222693653D0033DAD8 /* BoardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AD6212693653D0033DAD8 /* BoardViewController.swift */; };
+		BD0AD6242693655E0033DAD8 /* StoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AD6232693655E0033DAD8 /* StoreViewController.swift */; };
+		BD0AD62626936A8A0033DAD8 /* TripViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AD62526936A8A0033DAD8 /* TripViewController.swift */; };
 		BD39D4FC268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F7268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf */; };
 		BD39D4FD268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F8268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf */; };
 		BD39D4FE268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F9268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf */; };
@@ -58,6 +68,16 @@
 		40B5A091268EE35100A89875 /* AddTripViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTripViewController.swift; sourceTree = "<group>"; };
 		4BD67503EA76B9E8E80971F1 /* Pods_DooRiBon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DooRiBon.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		865B67CA1EA48E50F6BF455F /* Pods-DooRiBon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DooRiBon.release.xcconfig"; path = "Target Support Files/Pods-DooRiBon/Pods-DooRiBon.release.xcconfig"; sourceTree = "<group>"; };
+		BD0AD60D269361D50033DAD8 /* TripStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TripStoryboard.storyboard; sourceTree = "<group>"; };
+		BD0AD615269363D10033DAD8 /* MemberStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MemberStoryboard.storyboard; sourceTree = "<group>"; };
+		BD0AD617269363D90033DAD8 /* PlanStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PlanStoryboard.storyboard; sourceTree = "<group>"; };
+		BD0AD619269363E30033DAD8 /* BoardStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BoardStoryboard.storyboard; sourceTree = "<group>"; };
+		BD0AD61B269363ED0033DAD8 /* StoreStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = StoreStoryboard.storyboard; sourceTree = "<group>"; };
+		BD0AD61D269364D90033DAD8 /* MemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberViewController.swift; sourceTree = "<group>"; };
+		BD0AD61F269365050033DAD8 /* PlanViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanViewController.swift; sourceTree = "<group>"; };
+		BD0AD6212693653D0033DAD8 /* BoardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardViewController.swift; sourceTree = "<group>"; };
+		BD0AD6232693655E0033DAD8 /* StoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreViewController.swift; sourceTree = "<group>"; };
+		BD0AD62526936A8A0033DAD8 /* TripViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripViewController.swift; sourceTree = "<group>"; };
 		BD39D4F7268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Regular.ttf"; sourceTree = "<group>"; };
 		BD39D4F8268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Medium.ttf"; sourceTree = "<group>"; };
 		BD39D4F9268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Thin.ttf"; sourceTree = "<group>"; };
@@ -134,16 +154,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		BD55F43D26919BF8004E7114 /* JoinTrip */ = {
-			isa = PBXGroup;
-			children = (
-				BD55F43E26919C17004E7114 /* JoinTripStoryboard.storyboard */,
-				BD55F44026919C2B004E7114 /* JoinTripViewController.swift */,
-				BD4EF4902691CB8300A6362D /* CodeTextField.swift */,
-			);
-			path = JoinTrip;
-			sourceTree = "<group>";
-		};
 		40AE7825268F7F680058806B /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -170,6 +180,65 @@
 				40B5A091268EE35100A89875 /* AddTripViewController.swift */,
 			);
 			path = AddTrip;
+			sourceTree = "<group>";
+		};
+		BD0AD610269362DB0033DAD8 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				BD0AD60D269361D50033DAD8 /* TripStoryboard.storyboard */,
+				BD0AD62526936A8A0033DAD8 /* TripViewController.swift */,
+				BD0AD612269363150033DAD8 /* Member */,
+				BD0AD614269363480033DAD8 /* Plan */,
+				BD0AD611269363090033DAD8 /* Board */,
+				BD0AD613269363220033DAD8 /* Store */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		BD0AD611269363090033DAD8 /* Board */ = {
+			isa = PBXGroup;
+			children = (
+				BD0AD619269363E30033DAD8 /* BoardStoryboard.storyboard */,
+				BD0AD6212693653D0033DAD8 /* BoardViewController.swift */,
+			);
+			path = Board;
+			sourceTree = "<group>";
+		};
+		BD0AD612269363150033DAD8 /* Member */ = {
+			isa = PBXGroup;
+			children = (
+				BD0AD615269363D10033DAD8 /* MemberStoryboard.storyboard */,
+				BD0AD61D269364D90033DAD8 /* MemberViewController.swift */,
+			);
+			path = Member;
+			sourceTree = "<group>";
+		};
+		BD0AD613269363220033DAD8 /* Store */ = {
+			isa = PBXGroup;
+			children = (
+				BD0AD61B269363ED0033DAD8 /* StoreStoryboard.storyboard */,
+				BD0AD6232693655E0033DAD8 /* StoreViewController.swift */,
+			);
+			path = Store;
+			sourceTree = "<group>";
+		};
+		BD0AD614269363480033DAD8 /* Plan */ = {
+			isa = PBXGroup;
+			children = (
+				BD0AD617269363D90033DAD8 /* PlanStoryboard.storyboard */,
+				BD0AD61F269365050033DAD8 /* PlanViewController.swift */,
+			);
+			path = Plan;
+			sourceTree = "<group>";
+		};
+		BD55F43D26919BF8004E7114 /* JoinTrip */ = {
+			isa = PBXGroup;
+			children = (
+				BD55F43E26919C17004E7114 /* JoinTripStoryboard.storyboard */,
+				BD55F44026919C2B004E7114 /* JoinTripViewController.swift */,
+				BD4EF4902691CB8300A6362D /* CodeTextField.swift */,
+			);
+			path = JoinTrip;
 			sourceTree = "<group>";
 		};
 		BD75C2BB268B4B3700C4F233 = {
@@ -216,6 +285,7 @@
 		BD75C2DC268B4DFD00C4F233 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				BD0AD610269362DB0033DAD8 /* Base */,
 				BD55F43D26919BF8004E7114 /* JoinTrip */,
 				BD75C2E3268B522000C4F233 /* Main */,
 				0A1BD3B8268E192400702EC5 /* Common */,
@@ -398,14 +468,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDF1C11A268E287900C82CF6 /* Colors.xcassets in Resources */,
+				BD0AD616269363D10033DAD8 /* MemberStoryboard.storyboard in Resources */,
 				BD55F43F26919C17004E7114 /* JoinTripStoryboard.storyboard in Resources */,
+				BD0AD60E269361D50033DAD8 /* TripStoryboard.storyboard in Resources */,
+				BD0AD618269363D90033DAD8 /* PlanStoryboard.storyboard in Resources */,
 				BD39D4FE268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf in Resources */,
 				40B5A090268EE2E500A89875 /* AddTripStoryboard.storyboard in Resources */,
+				BD0AD61C269363ED0033DAD8 /* StoreStoryboard.storyboard in Resources */,
 				BD39D4FC268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf in Resources */,
 				BD75C2D4268B4B3900C4F233 /* LaunchScreen.storyboard in Resources */,
 				BD75C2D1268B4B3900C4F233 /* Assets.xcassets in Resources */,
 				BD39D500268DE80D004714B6 /* SpoqaHanSansNeo-Light.ttf in Resources */,
 				0A1BD3C0268E1E3D00702EC5 /* PagerTabSampleViewControllerStoryboard.storyboard in Resources */,
+				BD0AD61A269363E30033DAD8 /* BoardStoryboard.storyboard in Resources */,
 				BD39D4FD268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf in Resources */,
 				40AE782B268F7FED0058806B /* PhotoCollectionViewCell.xib in Resources */,
 				BD75C2E5268B52AD00C4F233 /* MainStoryboard.storyboard in Resources */,
@@ -463,9 +538,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				40B5A092268EE35100A89875 /* AddTripViewController.swift in Sources */,
+				BD0AD61E269364D90033DAD8 /* MemberViewController.swift in Sources */,
 				BD75C2C8268B4B3800C4F233 /* AppDelegate.swift in Sources */,
+				BD0AD62626936A8A0033DAD8 /* TripViewController.swift in Sources */,
 				BD75C2CA268B4B3800C4F233 /* SceneDelegate.swift in Sources */,
+				BD0AD6222693653D0033DAD8 /* BoardViewController.swift in Sources */,
 				BD75C2E7268B52BD00C4F233 /* MainViewController.swift in Sources */,
+				BD0AD6242693655E0033DAD8 /* StoreViewController.swift in Sources */,
+				BD0AD620269365050033DAD8 /* PlanViewController.swift in Sources */,
 				BD75C304268B5C7300C4F233 /* UIView+Extension.swift in Sources */,
 				40AE782A268F7FED0058806B /* PhotoCollectionViewCell.swift in Sources */,
 				0A1BD3BC268E1C6C00702EC5 /* PagerTabSampleViewController.swift in Sources */,

--- a/DooRiBon/DooRiBon/Application/SceneDelegate.swift
+++ b/DooRiBon/DooRiBon/Application/SceneDelegate.swift
@@ -19,11 +19,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         
         // 맨 처음 보여줄 뷰 컨트롤러 객체 생성 (루트 뷰 컨트롤러로 사용할 객체)
-        let rootViewController = UIStoryboard(name: "MainStoryboard", bundle: nil)
-            .instantiateViewController(identifier: "MainViewController")
+//        let rootViewController = UIStoryboard(name: "MainStoryboard", bundle: nil)
+//            .instantiateViewController(identifier: "MainViewController")
+        let rootViewController = UIStoryboard(name: "TripStoryboard", bundle: nil)
+            .instantiateViewController(identifier: "TripViewController")
         
         // 윈도우 위에 쌓이는 것 중에서 윈도우와 가장 근접한 부분을 rootViewController 라고 함
         window?.rootViewController = UINavigationController(rootViewController: rootViewController)
+
         // 생성한 윈도우를 핵심 윈도우로 보여줌 (윈도우는 여러 개 생성 가능)
         window?.makeKeyAndVisible()
 

--- a/DooRiBon/DooRiBon/Application/SceneDelegate.swift
+++ b/DooRiBon/DooRiBon/Application/SceneDelegate.swift
@@ -19,10 +19,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         
         // 맨 처음 보여줄 뷰 컨트롤러 객체 생성 (루트 뷰 컨트롤러로 사용할 객체)
-//        let rootViewController = UIStoryboard(name: "MainStoryboard", bundle: nil)
-//            .instantiateViewController(identifier: "MainViewController")
-        let rootViewController = UIStoryboard(name: "TripStoryboard", bundle: nil)
-            .instantiateViewController(identifier: "TripViewController")
+        let rootViewController = UIStoryboard(name: "MainStoryboard", bundle: nil)
+            .instantiateViewController(identifier: "MainViewController")
         
         // 윈도우 위에 쌓이는 것 중에서 윈도우와 가장 근접한 부분을 rootViewController 라고 함
         window?.rootViewController = UINavigationController(rootViewController: rootViewController)

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconBoardActiveIos.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconBoardActiveIos.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "filename" : "iconBoardActiveIos.png",
-      "scale" : "1x",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "iconBoardActiveIos@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "iconBoardActiveIos@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconBoardInactiveIos.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconBoardInactiveIos.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconCalendarActiveIos.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconCalendarActiveIos.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "iconCalendarActiveIos.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "iconCalendarActiveIos@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "scale" : "3x",
       "filename" : "iconCalendarActiveIos@3x.png",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconCalendarInactiveIos.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconCalendarInactiveIos.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconPeopleActiveIos.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconPeopleActiveIos.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconPeopleInactiveIos.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconPeopleInactiveIos.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconSaveActive.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconSaveActive.imageset/Contents.json
@@ -6,8 +6,8 @@
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "iconSaveActive@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
@@ -17,7 +17,10 @@
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconSaveInactive.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconSaveInactive.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardStoryboard.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--보드-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="BoardViewController" id="Y6W-OH-hqX" customClass="BoardViewController" customModule="DooRiBon" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="보드" image="iconBoardInactiveIos" selectedImage="iconBoardActiveIos" id="qOq-cj-B3K">
+                        <inset key="imageInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-12"/>
+                    </tabBarItem>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="139"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="iconBoardActiveIos" width="30.5" height="30"/>
+        <image name="iconBoardInactiveIos" width="30" height="30"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
@@ -1,0 +1,17 @@
+//
+//  BoardViewController.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/06.
+//
+
+import UIKit
+
+class BoardViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+//        view.backgroundColor = .blue
+    }
+}

--- a/DooRiBon/DooRiBon/Sources/Base/Member/MemberStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Member/MemberStoryboard.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--멤버-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="MemberViewController" id="Y6W-OH-hqX" customClass="MemberViewController" customModule="DooRiBon" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="멤버" image="iconPeopleInactiveIos" selectedImage="iconPeopleActiveIos" id="9SQ-1c-JHc">
+                        <inset key="imageInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-12"/>
+                    </tabBarItem>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="141" y="139"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="iconPeopleActiveIos" width="24.333333969116211" height="24"/>
+        <image name="iconPeopleInactiveIos" width="24.333333969116211" height="24"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/DooRiBon/DooRiBon/Sources/Base/Member/MemberViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Member/MemberViewController.swift
@@ -1,0 +1,17 @@
+//
+//  MemberViewController.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/06.
+//
+
+import UIKit
+
+class MemberViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+//        view.backgroundColor = .red
+    }
+}

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--일정-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="PlanViewController" id="Y6W-OH-hqX" customClass="PlanViewController" customModule="DooRiBon" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="일정" image="iconCalendarInactiveIos" selectedImage="iconCalendarActiveIos" id="C5S-tK-Amm">
+                        <inset key="imageInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-12"/>
+                    </tabBarItem>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="139"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="iconCalendarActiveIos" width="30" height="30"/>
+        <image name="iconCalendarInactiveIos" width="30" height="30"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
@@ -1,0 +1,17 @@
+//
+//  PlanViewController.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/06.
+//
+
+import UIKit
+
+class PlanViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+//        view.backgroundColor = .orange
+    }
+}

--- a/DooRiBon/DooRiBon/Sources/Base/Store/StoreStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Store/StoreStoryboard.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--저장-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="StoreViewController" id="Y6W-OH-hqX" customClass="StoreViewController" customModule="DooRiBon" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="저장" image="iconSaveInactive" selectedImage="iconSaveActive" id="BQW-7y-oh8">
+                        <inset key="imageInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-12"/>
+                    </tabBarItem>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="139"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="iconSaveActive" width="24" height="24"/>
+        <image name="iconSaveInactive" width="24" height="24"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/DooRiBon/DooRiBon/Sources/Base/Store/StoreViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Store/StoreViewController.swift
@@ -1,0 +1,17 @@
+//
+//  StoreViewController.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/06.
+//
+
+import UIKit
+
+class StoreViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+//        view.backgroundColor = .purple
+    }
+}

--- a/DooRiBon/DooRiBon/Sources/Base/TripStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/TripStoryboard.storyboard
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="S7L-3Y-fNE">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Trip View Controller-->
+        <scene sceneID="MeU-Mz-DhA">
+            <objects>
+                <tabBarController storyboardIdentifier="TripViewController" automaticallyAdjustsScrollViewInsets="NO" id="S7L-3Y-fNE" customClass="TripViewController" customModule="DooRiBon" customModuleProvider="target" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="NAz-DL-ieH" customClass="CustomTabBar" customModule="DooRiBon" customModuleProvider="target">
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="Kdz-Ih-ixc" kind="relationship" relationship="viewControllers" id="M8x-vM-Vfa"/>
+                        <segue destination="vbX-Sf-isF" kind="relationship" relationship="viewControllers" id="Kfy-l0-tsO"/>
+                        <segue destination="njv-6N-C8E" kind="relationship" relationship="viewControllers" id="KuJ-1B-fOZ"/>
+                        <segue destination="ReP-nd-1EK" kind="relationship" relationship="viewControllers" id="IHB-7I-A7G"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6Tv-gM-6Yo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-410" y="119"/>
+        </scene>
+        <!--MemberViewController-->
+        <scene sceneID="jH8-oS-boT">
+            <objects>
+                <viewControllerPlaceholder storyboardName="MemberStoryboard" referencedIdentifier="MemberViewController" id="Kdz-Ih-ixc" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="wnY-NA-IVm"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0Xy-KI-yzc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="504" y="-80"/>
+        </scene>
+        <!--PlanViewController-->
+        <scene sceneID="RAy-TE-1W6">
+            <objects>
+                <viewControllerPlaceholder storyboardName="PlanStoryboard" referencedIdentifier="PlanViewController" id="vbX-Sf-isF" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="Tu8-v5-akO"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bcH-AF-Byp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="487" y="15"/>
+        </scene>
+        <!--BoardViewController-->
+        <scene sceneID="doN-KS-Otl">
+            <objects>
+                <viewControllerPlaceholder storyboardName="BoardStoryboard" referencedIdentifier="BoardViewController" id="njv-6N-C8E" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="f0h-CO-aQH"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2eM-0X-Yt9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="487" y="119"/>
+        </scene>
+        <!--StoreViewController-->
+        <scene sceneID="yAA-RM-0FB">
+            <objects>
+                <viewControllerPlaceholder storyboardName="StoreStoryboard" referencedIdentifier="StoreViewController" id="ReP-nd-1EK" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="8eB-Do-qwu"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3cv-As-LTk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="492" y="222"/>
+        </scene>
+    </scenes>
+</document>

--- a/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
@@ -1,0 +1,86 @@
+//
+//  TripViewController.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/06.
+//
+
+/*
+ 탭바의 경우 Base/ 안에 위치해있고
+ - Member
+ - Plan
+ - Board
+ - Store
+ 총 4개의 스토리보드와 뷰 컨트롤러가 연결되어 있습니다.
+ 각각의 뷰 컨트롤러에서 작업해주시면 됩니다.
+ 
+ 아이콘과 타이틀의 위치가 약간씩 조정하기 힘든 부분이 있어서
+ 디테일한 것은 나중에 수정하도록 하겠습니다.
+ 
+ 아이템 Inset의 경우 임의로 지정해놔서 수정필요 ✨
+ */
+
+import UIKit
+
+class TripViewController: UITabBarController {
+    
+    // MARK: - Properties
+    
+    let appearance = UITabBarItem.appearance()
+
+    // MARK: - Life Cycles
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureUI()
+    }
+    
+
+    // MARK: - Configure
+
+    func configureUI() {
+        navigationController?.navigationBar.isHidden = true
+        
+        // 그림자 세팅
+        // - 기본 그림자 스타일 초기화
+        // - top 그림자 적용
+        UITabBar.clearShadow()
+        tabBar.layer.applyShadow(color: Colors.black2.color, alpha: 0.08, x: 0, y: -4, blur: 10)
+
+        // 탭바 속 아이템 간격 조정
+        tabBar.itemWidth = 60
+        tabBar.itemPositioning = .centered
+        
+        let selectedColor   = Colors.pointBlue.color
+        let unselectedColor = Colors.gray6.color
+        
+        // 아이템 색상 및 폰트 속성 조정
+        appearance.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: unselectedColor,
+                                           NSAttributedString.Key.font: UIFont.SpoqaHanSansNeo(.light, size: 12)], for: .normal)
+        appearance.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: selectedColor,
+                                           NSAttributedString.Key.font: UIFont.SpoqaHanSansNeo(.regular, size: 12)], for: .selected)
+        
+        // 타이틀 위치 조정
+        appearance.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: 8)
+    }
+}
+
+// MARK: - TabBar Extensions
+extension UITabBar {
+    // 기본 그림자 스타일을 초기화해야 커스텀 스타일을 적용할 수 있다.
+    static func clearShadow() {
+        UITabBar.appearance().shadowImage = UIImage()
+        UITabBar.appearance().backgroundImage = UIImage()
+        UITabBar.appearance().backgroundColor = UIColor.white
+    }
+}
+
+// MARK: - TabBar 높이 세팅 위한 클래스
+class CustomTabBar : UITabBar {
+    override open func sizeThatFits(_ size: CGSize) -> CGSize {
+        var sizeThatFits = super.sizeThatFits(size)
+        sizeThatFits.height = 82
+        return sizeThatFits
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약
- 사용될 탭바에 대해서 세팅하고 연결했습니다.
- iPhone SE2 기기로 확인결과 레이아웃이 깨지는 이슈가 발생합니다. 이후 다시 수정하겠습니다.

🌱 작업한 브랜치
- feature/15-bottom-tabbar

🌱 작업한 내용
- 탭 바 컨트롤러 생성
- 스토리보드 레퍼런스 연결
- 탭 바 쉐도우
- 아이콘 및 타이틀 조정 (커스텀)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|연결모습|<img src = "https://user-images.githubusercontent.com/61109660/124510273-6b894a00-de0e-11eb-9447-5a10b34bc692.gif" width = "250" />|
|쉐도우 적용| ![스크린샷 2021-07-06 오전 3 51 26](https://user-images.githubusercontent.com/61109660/124510354-94a9da80-de0e-11eb-82e1-6eb059dcc5a2.png)|
|iPhone SE2 이슈| ![스크린샷 2021-07-06 오전 3 52 08](https://user-images.githubusercontent.com/61109660/124510388-a55a5080-de0e-11eb-85d3-5d7a4f837470.png)|

## 📮 관련 이슈
- Resolved: #15 