### PR TITLE
[FEAT] #13 - 여행일정뷰 상단 고정 영역

### DIFF
--- a/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
+++ b/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		BD4EF4912691CB8300A6362D /* CodeTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4EF4902691CB8300A6362D /* CodeTextField.swift */; };
 		BD55F43F26919C17004E7114 /* JoinTripStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD55F43E26919C17004E7114 /* JoinTripStoryboard.storyboard */; };
 		BD55F44126919C2B004E7114 /* JoinTripViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD55F44026919C2B004E7114 /* JoinTripViewController.swift */; };
+		BD5CBC432694961C00935E79 /* DateCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5CBC412694961C00935E79 /* DateCollectionViewCell.swift */; };
+		BD5CBC442694961C00935E79 /* DateCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD5CBC422694961C00935E79 /* DateCollectionViewCell.xib */; };
 		BD75C2C8268B4B3800C4F233 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD75C2C7268B4B3800C4F233 /* AppDelegate.swift */; };
 		BD75C2CA268B4B3800C4F233 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD75C2C9268B4B3800C4F233 /* SceneDelegate.swift */; };
 		BD75C2D1268B4B3900C4F233 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD75C2D0268B4B3900C4F233 /* Assets.xcassets */; };
@@ -86,6 +88,8 @@
 		BD4EF4902691CB8300A6362D /* CodeTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextField.swift; sourceTree = "<group>"; };
 		BD55F43E26919C17004E7114 /* JoinTripStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = JoinTripStoryboard.storyboard; sourceTree = "<group>"; };
 		BD55F44026919C2B004E7114 /* JoinTripViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTripViewController.swift; sourceTree = "<group>"; };
+		BD5CBC412694961C00935E79 /* DateCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCollectionViewCell.swift; sourceTree = "<group>"; };
+		BD5CBC422694961C00935E79 /* DateCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DateCollectionViewCell.xib; sourceTree = "<group>"; };
 		BD75C2C4268B4B3800C4F233 /* DooRiBon.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DooRiBon.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD75C2C7268B4B3800C4F233 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD75C2C9268B4B3800C4F233 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -227,6 +231,7 @@
 			children = (
 				BD0AD617269363D90033DAD8 /* PlanStoryboard.storyboard */,
 				BD0AD61F269365050033DAD8 /* PlanViewController.swift */,
+				BD5CBC40269495DA00935E79 /* Cells */,
 			);
 			path = Plan;
 			sourceTree = "<group>";
@@ -239,6 +244,15 @@
 				BD4EF4902691CB8300A6362D /* CodeTextField.swift */,
 			);
 			path = JoinTrip;
+			sourceTree = "<group>";
+		};
+		BD5CBC40269495DA00935E79 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				BD5CBC422694961C00935E79 /* DateCollectionViewCell.xib */,
+				BD5CBC412694961C00935E79 /* DateCollectionViewCell.swift */,
+			);
+			path = Cells;
 			sourceTree = "<group>";
 		};
 		BD75C2BB268B4B3700C4F233 = {
@@ -481,6 +495,7 @@
 				BD39D500268DE80D004714B6 /* SpoqaHanSansNeo-Light.ttf in Resources */,
 				0A1BD3C0268E1E3D00702EC5 /* PagerTabSampleViewControllerStoryboard.storyboard in Resources */,
 				BD0AD61A269363E30033DAD8 /* BoardStoryboard.storyboard in Resources */,
+				BD5CBC442694961C00935E79 /* DateCollectionViewCell.xib in Resources */,
 				BD39D4FD268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf in Resources */,
 				40AE782B268F7FED0058806B /* PhotoCollectionViewCell.xib in Resources */,
 				BD75C2E5268B52AD00C4F233 /* MainStoryboard.storyboard in Resources */,
@@ -557,6 +572,7 @@
 				40AE782E268F81E20058806B /* PhotoCollectionViewModel.swift in Sources */,
 				BD75C2FA268B58E000C4F233 /* APIConstants.swift in Sources */,
 				BD55F44126919C2B004E7114 /* JoinTripViewController.swift in Sources */,
+				BD5CBC432694961C00935E79 /* DateCollectionViewCell.swift in Sources */,
 				BD75C2E9268B575E00C4F233 /* Device.swift in Sources */,
 				BD75C302268B5BDF00C4F233 /* FontEmpty.swift in Sources */,
 				0A1BD3BA268E193E00702EC5 /* PagerTab.swift in Sources */,

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconBackGrey.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconBackGrey.imageset/Contents.json
@@ -6,18 +6,21 @@
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "iconBackGrey@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "iconBackGrey@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconMypage.imageset/Contents.json
+++ b/DooRiBon/DooRiBon/Resources/Assets.xcassets/iconMypage.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "filename" : "iconMypage.png",
-      "scale" : "1x",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "iconMypage@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
+      "filename" : "iconMypage@3x.png",
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "iconMypage@3x.png"
+      "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/Cells/DateCollectionViewCell.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/Cells/DateCollectionViewCell.swift
@@ -1,0 +1,49 @@
+//
+//  DateCollectionViewCell.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/06.
+//
+
+import UIKit
+
+class DateCollectionViewCell: UICollectionViewCell {
+    // MARK: - Properties
+    
+    static let cellId = "DateCollectionViewCell"
+    
+    // MARK: - IBOutlets
+    
+    @IBOutlet weak var dayNumberLabel: UILabel!
+    @IBOutlet weak var dateLabel: UILabel!
+    @IBOutlet weak var focusView: UIView!
+    
+    // MARK: - Init
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureUI()
+    }
+    
+    // MARK: - Selection
+    // 셀 선택 상태에 따라서 UI 변경
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                focusView.isHidden = false
+                dateLabel.textColor = Colors.white9.color
+            } else {
+                focusView.isHidden = true
+                dateLabel.textColor = Colors.pointBlue.color
+            }
+        }
+    }
+    
+    // MARK: - Configure
+    
+    private func configureUI() {
+        dayNumberLabel.textColor = Colors.gray6.color
+        dayNumberLabel.font = UIFont.SpoqaHanSansNeo(.regular, size: 10)
+        dateLabel.textColor = Colors.pointBlue.color
+        dateLabel.font = UIFont.SpoqaHanSansNeo(.medium, size: 12)
+    }
+}

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/Cells/DateCollectionViewCell.xib
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/Cells/DateCollectionViewCell.xib
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DateCollectionViewCell" id="gTV-IL-0wX" customClass="DateCollectionViewCell" customModule="DooRiBon" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="24" height="53"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="24" height="53"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="D11" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MdL-tT-RQD">
+                        <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="24" id="Vbi-Lq-QDV"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kn9-rt-LmW">
+                        <rect key="frame" x="0.0" y="29" width="24" height="24"/>
+                        <color key="backgroundColor" name="pointBlue"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="24" id="wwE-JN-mq6"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="12"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="31" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n8J-JR-mKQ">
+                        <rect key="frame" x="0.0" y="29" width="24" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="24" id="F9O-Lh-T6X"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="n8J-JR-mKQ" secondAttribute="bottom" id="10w-lJ-c8T"/>
+                <constraint firstItem="MdL-tT-RQD" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="AXP-1T-baL"/>
+                <constraint firstAttribute="bottom" secondItem="kn9-rt-LmW" secondAttribute="bottom" id="C5W-LR-Qi4"/>
+                <constraint firstItem="n8J-JR-mKQ" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="E2c-Sf-9Qi"/>
+                <constraint firstItem="kn9-rt-LmW" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="Jjm-8k-OOd"/>
+                <constraint firstAttribute="trailing" secondItem="kn9-rt-LmW" secondAttribute="trailing" id="TB6-Tp-joM"/>
+                <constraint firstAttribute="trailing" secondItem="MdL-tT-RQD" secondAttribute="trailing" id="roJ-Pb-9SI"/>
+                <constraint firstAttribute="trailing" secondItem="n8J-JR-mKQ" secondAttribute="trailing" id="sTj-Ys-z2t"/>
+                <constraint firstAttribute="bottom" secondItem="n8J-JR-mKQ" secondAttribute="bottom" id="xjo-dB-fOg"/>
+                <constraint firstItem="MdL-tT-RQD" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="zOz-kg-xTX"/>
+            </constraints>
+            <size key="customSize" width="85" height="114"/>
+            <connections>
+                <outlet property="dateLabel" destination="n8J-JR-mKQ" id="xkK-Ic-a45"/>
+                <outlet property="dayNumberLabel" destination="MdL-tT-RQD" id="DtP-pb-P0o"/>
+                <outlet property="focusView" destination="kn9-rt-LmW" id="rD9-eg-qjv"/>
+            </connections>
+            <point key="canvasLocation" x="-102.89855072463769" y="-71.316964285714278"/>
+        </collectionViewCell>
+    </objects>
+    <resources>
+        <namedColor name="pointBlue">
+            <color red="0.41999998688697815" green="0.56099998950958252" blue="0.97600001096725464" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
@@ -4,34 +4,313 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="SpoqaHanSansNeo-Bold.ttf">
+            <string>SpoqaHanSansNeo-Bold</string>
+        </array>
+        <array key="SpoqaHanSansNeo-Medium.ttf">
+            <string>SpoqaHanSansNeo-Medium</string>
+        </array>
+        <array key="SpoqaHanSansNeo-Regular.ttf">
+            <string>SpoqaHanSansNeo-Regular</string>
+        </array>
+    </customFonts>
     <scenes>
-        <!--일정-->
+        <!--Plan View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
                 <viewController storyboardIdentifier="PlanViewController" id="Y6W-OH-hqX" customClass="PlanViewController" customModule="DooRiBon" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lF5-i6-YmL">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="190"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021. 07. 29 - 08. 02" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fB8-4f-iJg">
+                                        <rect key="frame" x="18" y="86" width="152.5" height="20"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="Dcf-JH-SaN"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="16"/>
+                                        <color key="textColor" name="pointBlue"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="떠나요 두리번 to 제주" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ojm-ow-wk9">
+                                        <rect key="frame" x="18" y="110" width="209.5" height="32"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="32" id="veV-vs-jiQ"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="23"/>
+                                        <color key="textColor" name="black1"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LAl-MH-Pxe">
+                                        <rect key="frame" x="234.5" y="115" width="20" height="22"/>
+                                        <state key="normal" image="iconSettings"/>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hE5-eM-Acp">
+                                        <rect key="frame" x="6" y="46" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="TFI-wT-eqp"/>
+                                            <constraint firstAttribute="height" constant="24" id="l0B-oZ-S0V"/>
+                                        </constraints>
+                                        <state key="normal" title="Button" image="iconBackGrey"/>
+                                        <connections>
+                                            <action selector="backButtonClicked:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="cyi-f1-K08"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vp7-EU-5o5">
+                                        <rect key="frame" x="336" y="46" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="24" id="X9f-sN-Duu"/>
+                                            <constraint firstAttribute="width" constant="24" id="cFE-1b-jzO"/>
+                                        </constraints>
+                                        <state key="normal" title="Button" image="iconMypage"/>
+                                        <connections>
+                                            <action selector="profileButtonClicked:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="0AQ-9T-SyP"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z33-lt-xgq">
+                                        <rect key="frame" x="18" y="150" width="109" height="28"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconAirplaneFill" translatesAutoresizingMaskIntoConstraints="NO" id="hjM-cf-zJZ">
+                                                <rect key="frame" x="8" y="4" width="20" height="20"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="20" id="aYj-bF-J7D"/>
+                                                    <constraint firstAttribute="height" constant="20" id="vUt-Me-1mj"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제주도 제주시" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Evm-y2-Kk9">
+                                                <rect key="frame" x="29" y="6.5" width="72" height="15.5"/>
+                                                <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
+                                                <color key="textColor" name="gray4"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="hjM-cf-zJZ" firstAttribute="leading" secondItem="z33-lt-xgq" secondAttribute="leading" constant="8" id="0LR-7L-2dt"/>
+                                            <constraint firstItem="Evm-y2-Kk9" firstAttribute="leading" secondItem="hjM-cf-zJZ" secondAttribute="trailing" constant="1" id="8me-dn-4Gc"/>
+                                            <constraint firstAttribute="trailing" secondItem="Evm-y2-Kk9" secondAttribute="trailing" constant="8" id="En8-Vm-zeH"/>
+                                            <constraint firstItem="hjM-cf-zJZ" firstAttribute="centerY" secondItem="z33-lt-xgq" secondAttribute="centerY" id="OSU-sO-Fiw"/>
+                                            <constraint firstAttribute="height" constant="28" id="Vsl-Mc-L7f"/>
+                                            <constraint firstAttribute="width" constant="109" id="hYS-Ti-QmK"/>
+                                            <constraint firstItem="Evm-y2-Kk9" firstAttribute="centerY" secondItem="hjM-cf-zJZ" secondAttribute="centerY" id="owf-xU-Hhz"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="14"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Ub-0n-Rfa">
+                                        <rect key="frame" x="136" y="150" width="161" height="28"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUserMainMid" translatesAutoresizingMaskIntoConstraints="NO" id="ckr-1p-gdp">
+                                                <rect key="frame" x="8" y="5" width="18" height="18"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="18" id="q88-bN-AZn"/>
+                                                    <constraint firstAttribute="height" constant="18" id="xgA-S3-MJa"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="김민영님 외 4명과 함께" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e21-eX-ImF">
+                                                <rect key="frame" x="30" y="6.5" width="123" height="15.5"/>
+                                                <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
+                                                <color key="textColor" name="gray4"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="ckr-1p-gdp" firstAttribute="centerY" secondItem="6Ub-0n-Rfa" secondAttribute="centerY" id="7Y6-mn-e75"/>
+                                            <constraint firstItem="ckr-1p-gdp" firstAttribute="leading" secondItem="6Ub-0n-Rfa" secondAttribute="leading" constant="8" id="OIb-dd-e5B"/>
+                                            <constraint firstAttribute="height" constant="28" id="XZC-pJ-VXr"/>
+                                            <constraint firstAttribute="trailing" secondItem="e21-eX-ImF" secondAttribute="trailing" constant="8" id="m3K-dA-gLn"/>
+                                            <constraint firstAttribute="width" constant="161" id="wQZ-sE-bln"/>
+                                            <constraint firstItem="e21-eX-ImF" firstAttribute="centerY" secondItem="ckr-1p-gdp" secondAttribute="centerY" id="wnB-nc-FT5"/>
+                                            <constraint firstItem="e21-eX-ImF" firstAttribute="leading" secondItem="ckr-1p-gdp" secondAttribute="trailing" constant="4" id="wwQ-hr-32w"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="14"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dyw-FO-wDa">
+                                        <rect key="frame" x="136" y="150" width="147" height="28"/>
+                                        <connections>
+                                            <action selector="memberButtonClicked:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="8TO-uU-dlq"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oug-eK-KnA" userLabel="plusButton">
+                                        <rect key="frame" x="283" y="147" width="35" height="34"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="34" id="ZVh-Ya-8Q7"/>
+                                            <constraint firstAttribute="width" constant="35" id="nCW-7Y-rno"/>
+                                        </constraints>
+                                        <state key="normal" image="btnAddpeopleCopycode"/>
+                                        <connections>
+                                            <action selector="codeCopyButtonClicked:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="CiQ-p7-Cp1"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" name="backgroundBlue"/>
+                                <constraints>
+                                    <constraint firstItem="6Ub-0n-Rfa" firstAttribute="leading" secondItem="z33-lt-xgq" secondAttribute="trailing" constant="9" id="0H0-2Y-bbz"/>
+                                    <constraint firstItem="hE5-eM-Acp" firstAttribute="leading" secondItem="lF5-i6-YmL" secondAttribute="leading" constant="6" id="1MP-DT-9K9"/>
+                                    <constraint firstItem="Oug-eK-KnA" firstAttribute="trailing" secondItem="6Ub-0n-Rfa" secondAttribute="trailing" constant="21" id="Fs8-MD-Ada"/>
+                                    <constraint firstItem="Vp7-EU-5o5" firstAttribute="centerY" secondItem="hE5-eM-Acp" secondAttribute="centerY" id="GZP-HB-KXO"/>
+                                    <constraint firstItem="fB8-4f-iJg" firstAttribute="leading" secondItem="lF5-i6-YmL" secondAttribute="leading" constant="18" id="JB5-qH-1hw"/>
+                                    <constraint firstItem="6Ub-0n-Rfa" firstAttribute="centerY" secondItem="z33-lt-xgq" secondAttribute="centerY" id="NbD-uh-d4Z"/>
+                                    <constraint firstItem="hE5-eM-Acp" firstAttribute="top" secondItem="lF5-i6-YmL" secondAttribute="top" constant="46" id="Rdj-PT-Y8d"/>
+                                    <constraint firstItem="LAl-MH-Pxe" firstAttribute="leading" secondItem="ojm-ow-wk9" secondAttribute="trailing" constant="7" id="VOR-pW-BPq"/>
+                                    <constraint firstAttribute="height" constant="190" id="VZK-vF-J2k"/>
+                                    <constraint firstItem="ojm-ow-wk9" firstAttribute="leading" secondItem="fB8-4f-iJg" secondAttribute="leading" id="Veq-JE-7wG"/>
+                                    <constraint firstAttribute="trailing" secondItem="Vp7-EU-5o5" secondAttribute="trailing" constant="15" id="cwc-lB-bOG"/>
+                                    <constraint firstItem="LAl-MH-Pxe" firstAttribute="centerY" secondItem="ojm-ow-wk9" secondAttribute="centerY" id="d0h-Io-1LY"/>
+                                    <constraint firstItem="z33-lt-xgq" firstAttribute="top" secondItem="ojm-ow-wk9" secondAttribute="bottom" constant="8" id="dcv-a5-RHC"/>
+                                    <constraint firstItem="Oug-eK-KnA" firstAttribute="centerY" secondItem="6Ub-0n-Rfa" secondAttribute="centerY" id="eOq-D7-Of2"/>
+                                    <constraint firstItem="dyw-FO-wDa" firstAttribute="top" secondItem="6Ub-0n-Rfa" secondAttribute="top" id="hSV-j6-Skn"/>
+                                    <constraint firstItem="z33-lt-xgq" firstAttribute="leading" secondItem="ojm-ow-wk9" secondAttribute="leading" id="hzt-ZO-tQm"/>
+                                    <constraint firstItem="ojm-ow-wk9" firstAttribute="top" secondItem="fB8-4f-iJg" secondAttribute="bottom" constant="4" id="jCh-PK-zJW"/>
+                                    <constraint firstItem="fB8-4f-iJg" firstAttribute="top" secondItem="hE5-eM-Acp" secondAttribute="bottom" constant="16" id="li9-bd-n3A"/>
+                                    <constraint firstItem="dyw-FO-wDa" firstAttribute="leading" secondItem="6Ub-0n-Rfa" secondAttribute="leading" id="nQT-gS-5av"/>
+                                    <constraint firstItem="Oug-eK-KnA" firstAttribute="leading" secondItem="dyw-FO-wDa" secondAttribute="trailing" id="nZZ-ZW-mOv"/>
+                                    <constraint firstItem="dyw-FO-wDa" firstAttribute="bottom" secondItem="6Ub-0n-Rfa" secondAttribute="bottom" id="nuE-Im-Qfy"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B9K-oA-KgM">
+                                <rect key="frame" x="0.0" y="190" width="375" height="71"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cnf-GC-uwT">
+                                        <rect key="frame" x="0.0" y="0.0" width="79" height="71"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rit-r2-uHf">
+                                                <rect key="frame" x="34" y="13" width="19.5" height="10.5"/>
+                                                <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="8"/>
+                                                <color key="textColor" name="subBlue1"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="7" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7ZN-pz-hIT">
+                                                <rect key="frame" x="37" y="27" width="14" height="32"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="14" id="F9a-92-Cbj"/>
+                                                    <constraint firstAttribute="height" constant="32" id="VHi-4J-Aek"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="23"/>
+                                                <color key="textColor" name="pointBlue"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="7ZN-pz-hIT" secondAttribute="bottom" constant="12" id="FGg-C0-ae8"/>
+                                            <constraint firstItem="rit-r2-uHf" firstAttribute="top" secondItem="Cnf-GC-uwT" secondAttribute="top" constant="13" id="GH7-1D-XNy"/>
+                                            <constraint firstAttribute="width" constant="79" id="x3P-I4-RlH"/>
+                                            <constraint firstItem="7ZN-pz-hIT" firstAttribute="leading" secondItem="Cnf-GC-uwT" secondAttribute="leading" constant="37" id="xZY-2e-YN9"/>
+                                            <constraint firstItem="rit-r2-uHf" firstAttribute="leading" secondItem="Cnf-GC-uwT" secondAttribute="leading" constant="34" id="yNd-rm-t5X"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vcf-9p-7Ge">
+                                        <rect key="frame" x="79" y="9" width="1" height="53"/>
+                                        <color key="backgroundColor" name="gray7"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="53" id="3A3-1n-nEg"/>
+                                            <constraint firstAttribute="width" constant="1" id="x96-hr-i2z"/>
+                                        </constraints>
+                                    </view>
+                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="OeZ-ms-OfT">
+                                        <rect key="frame" x="80" y="0.0" width="295" height="71"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="vSu-SK-vEF">
+                                            <size key="itemSize" width="65" height="62"/>
+                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        </collectionViewFlowLayout>
+                                        <cells>
+                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="bps-om-00H">
+                                                <rect key="frame" x="0.0" y="4.5" width="65" height="62"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="lTr-9I-PFl">
+                                                    <rect key="frame" x="0.0" y="0.0" width="65" height="62"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                </collectionViewCellContentView>
+                                                <size key="customSize" width="65" height="62"/>
+                                            </collectionViewCell>
+                                        </cells>
+                                    </collectionView>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="Vcf-9p-7Ge" firstAttribute="leading" secondItem="Cnf-GC-uwT" secondAttribute="trailing" id="1eJ-sx-ioZ"/>
+                                    <constraint firstAttribute="height" constant="71" id="5iV-nt-Xho"/>
+                                    <constraint firstItem="OeZ-ms-OfT" firstAttribute="top" secondItem="B9K-oA-KgM" secondAttribute="top" id="9og-wX-08K"/>
+                                    <constraint firstAttribute="bottom" secondItem="Cnf-GC-uwT" secondAttribute="bottom" id="Hbr-Sp-ccc"/>
+                                    <constraint firstItem="Cnf-GC-uwT" firstAttribute="leading" secondItem="B9K-oA-KgM" secondAttribute="leading" id="gLX-87-LUZ"/>
+                                    <constraint firstItem="Cnf-GC-uwT" firstAttribute="top" secondItem="B9K-oA-KgM" secondAttribute="top" id="jph-hg-XJy"/>
+                                    <constraint firstAttribute="bottom" secondItem="OeZ-ms-OfT" secondAttribute="bottom" id="kA4-vM-p5H"/>
+                                    <constraint firstAttribute="trailing" secondItem="OeZ-ms-OfT" secondAttribute="trailing" id="q1d-p4-iNQ"/>
+                                    <constraint firstItem="Vcf-9p-7Ge" firstAttribute="centerY" secondItem="Cnf-GC-uwT" secondAttribute="centerY" id="zB1-bd-fYH"/>
+                                    <constraint firstItem="OeZ-ms-OfT" firstAttribute="leading" secondItem="Vcf-9p-7Ge" secondAttribute="trailing" id="zZe-Jv-WgV"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="lF5-i6-YmL" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="7Ml-w0-YLV"/>
+                            <constraint firstItem="B9K-oA-KgM" firstAttribute="top" secondItem="lF5-i6-YmL" secondAttribute="bottom" id="Epu-O6-Tzm"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="lF5-i6-YmL" secondAttribute="trailing" id="SCi-Ph-XKD"/>
+                            <constraint firstItem="lF5-i6-YmL" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="b8d-ET-K44"/>
+                            <constraint firstItem="B9K-oA-KgM" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="sdE-UB-koV"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="B9K-oA-KgM" secondAttribute="trailing" id="xU3-EY-P6L"/>
+                        </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="일정" image="iconCalendarInactiveIos" selectedImage="iconCalendarActiveIos" id="C5S-tK-Amm">
-                        <inset key="imageInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-12"/>
-                    </tabBarItem>
+                    <nil key="simulatedTopBarMetrics"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="calendarAreaView" destination="B9K-oA-KgM" id="Z9p-gl-zHU"/>
+                        <outlet property="calendarView" destination="OeZ-ms-OfT" id="ozh-U4-ueT"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="139" y="139"/>
+            <point key="canvasLocation" x="1077.5999999999999" y="138.98050974512745"/>
         </scene>
     </scenes>
     <resources>
-        <image name="iconCalendarActiveIos" width="30" height="30"/>
-        <image name="iconCalendarInactiveIos" width="30" height="30"/>
+        <image name="btnAddpeopleCopycode" width="29" height="29"/>
+        <image name="iconAirplaneFill" width="20" height="20"/>
+        <image name="iconBackGrey" width="24" height="24"/>
+        <image name="iconMypage" width="24" height="24"/>
+        <image name="iconSettings" width="20" height="20"/>
+        <image name="iconUserMainMid" width="18" height="18"/>
+        <namedColor name="backgroundBlue">
+            <color red="0.92500001192092896" green="0.94900000095367432" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="black1">
+            <color red="0.125" green="0.125" blue="0.125" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="gray4">
+            <color red="0.36899998784065247" green="0.39599999785423279" blue="0.41999998688697815" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="gray7">
+            <color red="0.91399997472763062" green="0.92199999094009399" blue="0.92900002002716064" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="pointBlue">
+            <color red="0.41999998688697815" green="0.56099998950958252" blue="0.97600001096725464" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="subBlue1">
+            <color red="0.60399997234344482" green="0.70599997043609619" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
@@ -26,7 +26,7 @@ class PlanViewController: UIViewController {
     }
     
     private var isSelectedArray: [Bool] = []  // 셀 선택 유무 담을 Bool 배열
-    private var todayDate: Int = 0            // 오늘 날짜 담을 변수 - 자료형 변경 가능
+    private var selectedDate: Int?         // 오늘 날짜를 디폴트 값으로 시작
     
     // MARK: - IBOutlets
 
@@ -40,8 +40,7 @@ class PlanViewController: UIViewController {
 
         configureUI()
         setupCollectionView()
-        setupDummyData()
-        getTodayInfo()
+        setupData()
     }
     
     // MARK: - IBActions
@@ -77,32 +76,33 @@ extension PlanViewController {
                                            blur: 10,
                                            spread: 0)
     }
+    
     /// CollectionView Setup
     private func setupCollectionView() {
         calendarView.delegate = self
         calendarView.dataSource = self
         calendarView.register(UINib(nibName: "DateCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: DateCollectionViewCell.cellId)
-        calendarView.allowsMultipleSelection = false
     }
+    
     /// Dummy Setup
-    private func setupDummyData() {
+    private func setupData() {
         dummyData.append(contentsOf: [
             6, 7, 8, 9, 10, 11,
             12, 13, 14, 15, 16, 17
         ])
-        
-        for _ in 0..<dummyData.count {
-            isSelectedArray.append(false)
-        }
+
+        selectedDate = getTodayInfo()
     }
+    
     /// Get Today - 오늘 날짜 얻어오는 함수
-    private func getTodayInfo() {
+    private func getTodayInfo() -> Int {
         let nowDate = Date() // 현재의 Date (ex: 2020-08-13 09:14:48 +0000)
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM" // 2020-08-13 16:30
         let str = dateFormatter.string(from: nowDate) // 현재 시간의 Date를 format에 맞춰 string으로 반환
-        todayDate = Int(str) ?? -1
+        return Int(str) ?? -1
     }
+    
     /// 셀 선택 상태 변경해주는 토글 함수
     private func toggleSelection(index: Int) {
         for i in 0..<isSelectedArray.count {
@@ -117,7 +117,9 @@ extension PlanViewController {
 
 // MARK: - Collection View Data Delegate
 extension PlanViewController: UICollectionViewDelegate {
-
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.selectedDate = dummyData[indexPath.row]
+    }
 }
 
 // MARK: - Collection View Data Source
@@ -134,10 +136,10 @@ extension PlanViewController: UICollectionViewDataSource {
         cell.dayNumberLabel.text = "D\(indexPath.row + 1)"
         cell.dateLabel.text = String(describing: dummyData[indexPath.row])
         
-        /// 오늘 날짜인 경우 셀이 선택된 상태로 시작
-        if dummyData[indexPath.row] == todayDate {
-            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+        /// 선택된 날짜일때만 isSelected 변경
+        if dummyData[indexPath.row] == selectedDate {
             cell.isSelected = true
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
         } else {
             cell.isSelected = false
         }

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
@@ -8,10 +8,163 @@
 import UIKit
 
 class PlanViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    lazy var calendar: Calendar = {
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.timeZone = .current
+        return gregorian
+    }()
+    
+    // MARK: - Dummy Data
+    
+    private var dummyData: [Int] = [] {
+        didSet {
+            calendarView.reloadData()
+        }
+    }
+    
+    private var isSelectedArray: [Bool] = []  // 셀 선택 유무 담을 Bool 배열
+    private var todayDate: Int = 0            // 오늘 날짜 담을 변수 - 자료형 변경 가능
+    
+    // MARK: - IBOutlets
 
+    @IBOutlet weak var calendarAreaView: UIView!
+    @IBOutlet weak var calendarView: UICollectionView!
+    
+    // MARK: - Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-//        view.backgroundColor = .orange
+        configureUI()
+        setupCollectionView()
+        setupDummyData()
+        getTodayInfo()
+    }
+    
+    // MARK: - IBActions
+    
+    @IBAction private func backButtonClicked(_ sender: UIButton) {
+        print("뒤로가기 버튼 클릭")
+    }
+    
+    @IBAction private func profileButtonClicked(_ sender: UIButton) {
+        print("프로필 버튼 클릭")
+    }
+    
+    @IBAction private func memberButtonClicked(_ sender: UIButton) {
+        print("멤버 버튼 클릭")
+    }
+    
+    @IBAction private func codeCopyButtonClicked(_ sender: UIButton) {
+        print("참여코드 복사 완료")
+    }
+}
+
+// MARK: - Helpers
+
+extension PlanViewController {
+    // MARK: - Configure
+    /// UI Setup
+    private func configureUI() {
+        navigationController?.navigationBar.isHidden = true
+        calendarAreaView.layer.applyShadow(color: .black,
+                                           alpha: 0.07,
+                                           x: 0,
+                                           y: 3,
+                                           blur: 10,
+                                           spread: 0)
+    }
+    /// CollectionView Setup
+    private func setupCollectionView() {
+        calendarView.delegate = self
+        calendarView.dataSource = self
+        calendarView.register(UINib(nibName: "DateCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: DateCollectionViewCell.cellId)
+        calendarView.allowsMultipleSelection = false
+    }
+    /// Dummy Setup
+    private func setupDummyData() {
+        dummyData.append(contentsOf: [
+            6, 7, 8, 9, 10, 11,
+            12, 13, 14, 15, 16, 17
+        ])
+        
+        for _ in 0..<dummyData.count {
+            isSelectedArray.append(false)
+        }
+    }
+    /// Get Today - 오늘 날짜 얻어오는 함수
+    private func getTodayInfo() {
+        let nowDate = Date() // 현재의 Date (ex: 2020-08-13 09:14:48 +0000)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM" // 2020-08-13 16:30
+        let str = dateFormatter.string(from: nowDate) // 현재 시간의 Date를 format에 맞춰 string으로 반환
+        todayDate = Int(str) ?? -1
+    }
+    /// 셀 선택 상태 변경해주는 토글 함수
+    private func toggleSelection(index: Int) {
+        for i in 0..<isSelectedArray.count {
+            if i == index {
+                isSelectedArray[i] = true
+            } else {
+                isSelectedArray[i] = false
+            }
+        }
+    }
+}
+
+// MARK: - Collection View Data Delegate
+extension PlanViewController: UICollectionViewDelegate {
+
+}
+
+// MARK: - Collection View Data Source
+extension PlanViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return dummyData.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateCollectionViewCell.cellId,
+                                                            for: indexPath) as? DateCollectionViewCell else { return UICollectionViewCell() }
+        
+        /// 데이터 표시
+        cell.dayNumberLabel.text = "D\(indexPath.row + 1)"
+        cell.dateLabel.text = String(describing: dummyData[indexPath.row])
+        
+        /// 오늘 날짜인 경우 셀이 선택된 상태로 시작
+        if dummyData[indexPath.row] == todayDate {
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+            cell.isSelected = true
+        } else {
+            cell.isSelected = false
+        }
+        
+        return cell
+    }
+}
+
+// MARK: - Collection View Flow Layout
+extension PlanViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        /// 셀 사이즈 우선 고정값으로 부여
+        return CGSize(width: 24, height: 53)
+    }
+
+    // 아이템 간격
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        0
+    }
+
+    // 라인 간격
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        18
+    }
+
+    // 전체 Edge
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets.init(top: 7, left: 21, bottom: 11, right: 21)
     }
 }


### PR DESCRIPTION

## 🌴 PR 요약
여행일정뷰 상단영역을 구현했습니다.

🌱 작업한 브랜치
- feature/#13

🌱 작업한 내용
- 캘린더 상단 영역 레이아웃 잡기
- 캘린더 날짜 계산
- 캘린더 일 영역 수평 스크롤 (범위 넘어갔을 때)
- 날짜 선택 액션

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src="https://user-images.githubusercontent.com/61109660/124732287-09cff980-df4e-11eb-87ea-6273cefd77ff.gif" width="200" />|

## 📮 관련 이슈
- Resolved: #13