### PR TITLE
[FEAT] #81 - 참여 코드 뷰 API 연결

### DIFF
--- a/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
+++ b/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		BD172597269C14BE000FB89B /* BoardPopupView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD172596269C14BE000FB89B /* BoardPopupView.xib */; };
 		BD1725C9269CA04F000FB89B /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1725C8269CA04F000FB89B /* NetworkResult.swift */; };
 		BD1725CB269CB39F000FB89B /* NetworkInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1725CA269CB39F000FB89B /* NetworkInfo.swift */; };
+		BD1725D5269D77CE000FB89B /* JoinTripDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1725D4269D77CE000FB89B /* JoinTripDataModel.swift */; };
 		BD39D4FC268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F7268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf */; };
 		BD39D4FD268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F8268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf */; };
 		BD39D4FE268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F9268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf */; };
@@ -179,6 +180,7 @@
 		BD172596269C14BE000FB89B /* BoardPopupView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BoardPopupView.xib; sourceTree = "<group>"; };
 		BD1725C8269CA04F000FB89B /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		BD1725CA269CB39F000FB89B /* NetworkInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInfo.swift; sourceTree = "<group>"; };
+		BD1725D4269D77CE000FB89B /* JoinTripDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTripDataModel.swift; sourceTree = "<group>"; };
 		BD39D4F7268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Regular.ttf"; sourceTree = "<group>"; };
 		BD39D4F8268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Medium.ttf"; sourceTree = "<group>"; };
 		BD39D4F9268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Thin.ttf"; sourceTree = "<group>"; };
@@ -532,12 +534,29 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		BD1725D2269D7724000FB89B /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				BD1725D4269D77CE000FB89B /* JoinTripDataModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		BD1725D3269D772F000FB89B /* Services */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		BD55F43D26919BF8004E7114 /* JoinTrip */ = {
 			isa = PBXGroup;
 			children = (
-				BD55F43E26919C17004E7114 /* JoinTripStoryboard.storyboard */,
 				BD55F44026919C2B004E7114 /* JoinTripViewController.swift */,
+				BD55F43E26919C17004E7114 /* JoinTripStoryboard.storyboard */,
 				BD4EF4902691CB8300A6362D /* CodeTextField.swift */,
+				BD1725D2269D7724000FB89B /* Models */,
+				BD1725D3269D772F000FB89B /* Services */,
 			);
 			path = JoinTrip;
 			sourceTree = "<group>";
@@ -972,6 +991,7 @@
 				0A1BD3BC268E1C6C00702EC5 /* PagerTabSampleViewController.swift in Sources */,
 				399C7016269B28A40017069C /* MemberViewController.swift in Sources */,
 				BD5EEC9826986AC600D09B11 /* BoardHeaderTableViewCell.swift in Sources */,
+				BD1725D5269D77CE000FB89B /* JoinTripDataModel.swift in Sources */,
 				BD75C2EF268B580900C4F233 /* ServiceEmpty.swift in Sources */,
 				BD75C2F8268B58B500C4F233 /* ProtocolEmpty.swift in Sources */,
 				BDCC367C2695DA66009AE274 /* PlanDataModel.swift in Sources */,

--- a/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
+++ b/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		BD1725C9269CA04F000FB89B /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1725C8269CA04F000FB89B /* NetworkResult.swift */; };
 		BD1725CB269CB39F000FB89B /* NetworkInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1725CA269CB39F000FB89B /* NetworkInfo.swift */; };
 		BD1725D5269D77CE000FB89B /* JoinTripDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1725D4269D77CE000FB89B /* JoinTripDataModel.swift */; };
+		BD1725D7269D78F7000FB89B /* JoinTripDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1725D6269D78F7000FB89B /* JoinTripDataService.swift */; };
 		BD39D4FC268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F7268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf */; };
 		BD39D4FD268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F8268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf */; };
 		BD39D4FE268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BD39D4F9268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf */; };
@@ -181,6 +182,7 @@
 		BD1725C8269CA04F000FB89B /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		BD1725CA269CB39F000FB89B /* NetworkInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInfo.swift; sourceTree = "<group>"; };
 		BD1725D4269D77CE000FB89B /* JoinTripDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTripDataModel.swift; sourceTree = "<group>"; };
+		BD1725D6269D78F7000FB89B /* JoinTripDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTripDataService.swift; sourceTree = "<group>"; };
 		BD39D4F7268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Regular.ttf"; sourceTree = "<group>"; };
 		BD39D4F8268DE80D004714B6 /* SpoqaHanSansNeo-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Medium.ttf"; sourceTree = "<group>"; };
 		BD39D4F9268DE80D004714B6 /* SpoqaHanSansNeo-Thin.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpoqaHanSansNeo-Thin.ttf"; sourceTree = "<group>"; };
@@ -545,6 +547,7 @@
 		BD1725D3269D772F000FB89B /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				BD1725D6269D78F7000FB89B /* JoinTripDataService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -973,6 +976,7 @@
 				BD0AD62626936A8A0033DAD8 /* TripViewController.swift in Sources */,
 				BDCC36772695C61C009AE274 /* PlanDataHeaderView.swift in Sources */,
 				BD75C2CA268B4B3800C4F233 /* SceneDelegate.swift in Sources */,
+				BD1725D7269D78F7000FB89B /* JoinTripDataService.swift in Sources */,
 				3975958D269B569D008E8360 /* TestChoiceViewController.swift in Sources */,
 				BD0AD6222693653D0033DAD8 /* BoardViewController.swift in Sources */,
 				408D1ADF26957D8F00BBC454 /* CalendarCell.swift in Sources */,

--- a/DooRiBon/DooRiBon/Resources/Network/APIConstants.swift
+++ b/DooRiBon/DooRiBon/Resources/Network/APIConstants.swift
@@ -29,4 +29,19 @@ struct APIConstants {
     
     // Base URL
     static let baseURL = "http://13.209.82.176:5000"
+    
+    // MARK: - /travel URLs
+    static let inviteCodeURL = baseURL + "/travel/group/:inviteCode"    // 여행 참여, 여행 정보 조회
+    
+    // MARK: - /auth/user URLs
+    
+    // MARK: - /schedule
+
+    // MARK: - /board
+    
+    // MARK: - /tendency
+    
+    // MARK: - /image
+    
+    // MARK: - /user/myPage
 }

--- a/DooRiBon/DooRiBon/Sources/JoinTrip/JoinTripStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/JoinTrip/JoinTripStoryboard.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
@@ -22,7 +22,7 @@
             <objects>
                 <viewController storyboardIdentifier="JoinTripViewController" id="Y6W-OH-hqX" customClass="JoinTripViewController" customModule="DooRiBon" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aoC-FT-XwD">
@@ -57,7 +57,7 @@
                                                 <rect key="frame" x="2" y="10" width="33" height="28"/>
                                                 <color key="textColor" name="pointBlue"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="24"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                                <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" name="white9"/>
@@ -83,7 +83,7 @@
                                                 <rect key="frame" x="2" y="10" width="33" height="28"/>
                                                 <color key="textColor" name="pointBlue"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="24"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                                <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" name="white9"/>
@@ -109,7 +109,7 @@
                                                 <rect key="frame" x="2" y="10" width="33" height="28"/>
                                                 <color key="textColor" name="pointBlue"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="24"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                                <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" name="white9"/>
@@ -135,7 +135,7 @@
                                                 <rect key="frame" x="2" y="10" width="33" height="28"/>
                                                 <color key="textColor" name="pointBlue"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="24"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                                <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" name="white9"/>
@@ -161,7 +161,7 @@
                                                 <rect key="frame" x="2" y="10" width="33" height="28"/>
                                                 <color key="textColor" name="pointBlue"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="24"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                                <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" name="white9"/>
@@ -187,7 +187,7 @@
                                                 <rect key="frame" x="2" y="10" width="33" height="28"/>
                                                 <color key="textColor" name="pointBlue"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="24"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                                <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" name="white9"/>

--- a/DooRiBon/DooRiBon/Sources/JoinTrip/JoinTripViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/JoinTrip/JoinTripViewController.swift
@@ -59,13 +59,13 @@ class JoinTripViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction func joinTripButtonClicked(_ sender: Any) {
-        
+        let inviteCode = checkInviteCode()
+        getTripData(inviteCode: inviteCode)
     }
     
     @IBAction func backButtonClicked(_ sender: Any) {
         self.navigationController?.popViewController(animated: true)
     }
-    
 }
 
 // MARK: - Set up
@@ -185,6 +185,35 @@ extension JoinTripViewController {
             joinButton.setTitle("입력 완료", for: .normal)
             activateTotalArea()
         }
+    }
+    
+    // MARK: - Service
+    private func getTripData(inviteCode: String) {
+        JoinTripDataService.shared.getTripInfoWithInviteCode(inviteCode: inviteCode) { (response) in
+            switch(response)
+            {
+            case .success(let data) :
+                print(data)
+            case .requestErr(let message) :
+                print(message)
+            case .pathErr :
+                print("pathERR")
+            case .serverErr:
+                print("serverERR")
+            case .networkFail:
+                print("networkFail")
+            }
+        }
+    }
+    
+    private func checkInviteCode() -> String {
+        var inviteCode = ""
+        codeTextField.forEach {
+            if let code = $0.text {
+                inviteCode += code
+            }
+        }
+        return inviteCode
     }
 }
 

--- a/DooRiBon/DooRiBon/Sources/JoinTrip/JoinTripViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/JoinTrip/JoinTripViewController.swift
@@ -194,14 +194,10 @@ extension JoinTripViewController: UITextFieldDelegate {
     // MARK: - 숫자 1개만 입력 가능하도록 제한
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        /// 숫자만 입력 가능하도록 - 사실 이 코드는 없어도 될 거라고 생각은 하지만 최대한 안전하게
-        let allowedCharacters = CharacterSet.decimalDigits
-        let characterSet = CharacterSet(charactersIn: string)
-        
         /// textField 델리게이트에서 현재 input창에 입력된 값을 구하고 싶은 경우 - 글자 수 구하는 데 사용
         let currentString: NSString = textField.text! as NSString
         let newString: NSString =  currentString.replacingCharacters(in: range, with: string) as NSString
         
-        return allowedCharacters.isSuperset(of: characterSet) && newString.length <= 1
+        return newString.length <= 1
     }
 }

--- a/DooRiBon/DooRiBon/Sources/JoinTrip/Models/JoinTripDataModel.swift
+++ b/DooRiBon/DooRiBon/Sources/JoinTrip/Models/JoinTripDataModel.swift
@@ -1,0 +1,47 @@
+//
+//  JoinTripDataModel.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/13.
+//
+
+/*
+ 여행 정보를 Response로 받아오는데 , 동일한 형태가 있으면 하나로 사용해도 괜찮을 듯
+ {
+     "status": 200,
+     "success": true,
+     "message": "참여 코드로 여행 찾기 성공",
+     "data": {
+         "groupId": "60ebfdfabc1ffc1325a15f22",
+         "travelName": "배고픈 여행",
+         "host": "채정아",
+         "destination": "우리 집",
+         "startDate": "2021-8-21-0:0",
+         "endDate": "2021-8-24-0:0",
+         "image": "https://dooribon.s3.ap-northeast-2.amazonaws.com/1.png"
+     }
+ }
+ 
+ - 네이밍에 대한 고민
+ */
+import Foundation
+
+// MARK: - JoinTrip 전체 데이터 모델
+struct JoinTripDataModel: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: JoinTripData?
+}
+
+// MARK: - JoinTrip 데이터
+struct JoinTripData: Codable {
+    let groupID, travelName, host, destination: String
+    let startDate, endDate: String
+    let image: String
+
+    enum CodingKeys: String, CodingKey {
+        case groupID = "groupId"
+        case travelName, host, destination, startDate, endDate, image
+    }
+}

--- a/DooRiBon/DooRiBon/Sources/JoinTrip/Models/JoinTripDataModel.swift
+++ b/DooRiBon/DooRiBon/Sources/JoinTrip/Models/JoinTripDataModel.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 // MARK: - JoinTrip 전체 데이터 모델
-struct JoinTripDataModel: Codable {
+struct JoinTripResponse: Codable {
     let status: Int
     let success: Bool
     let message: String

--- a/DooRiBon/DooRiBon/Sources/JoinTrip/Services/JoinTripDataService.swift
+++ b/DooRiBon/DooRiBon/Sources/JoinTrip/Services/JoinTripDataService.swift
@@ -14,11 +14,18 @@ struct JoinTripDataService {
     
     static let shared = JoinTripDataService()
     
+    // MARK: - URL Create
+    
+    private func makeURL(inviteCode: String) -> String {
+        let url = APIConstants.inviteCodeURL.replacingOccurrences(of: ":inviteCode", with: inviteCode)
+        return url
+    }
+    
     // MARK: - API 요청 함수
     
-    func getTripInfoWithInviteCode(completion: @escaping (NetworkResult<Any>)->()) {
+    func getTripInfoWithInviteCode(inviteCode: String, completion: @escaping (NetworkResult<Any>)->()) {
         
-        let url: String = APIConstants.inviteCodeURL            // URL
+        let url: String = makeURL(inviteCode: inviteCode)       // URL
         let header: HTTPHeaders = NetworkInfo.headerWithToken   // Headers
         
         let dataRequest = AF.request(url,
@@ -31,10 +38,6 @@ struct JoinTripDataService {
             case .success:
                 guard let statusCode = response.response?.statusCode else { return }
                 guard let data = response.value else { return }
-                
-                print("😁 \(statusCode)")
-                print("💽 \(data)")
-                    
                 completion(judgeStatus(status: statusCode, data: data))
                 
             case .failure(let err):
@@ -48,7 +51,7 @@ struct JoinTripDataService {
     
     private func judgeStatus(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(JoinTripData.self, from: data) else {return .pathErr}
+        guard let decodedData = try? decoder.decode(JoinTripResponse.self, from: data) else {return .pathErr}
         
         switch status {
         case 200: return .success(decodedData)

--- a/DooRiBon/DooRiBon/Sources/JoinTrip/Services/JoinTripDataService.swift
+++ b/DooRiBon/DooRiBon/Sources/JoinTrip/Services/JoinTripDataService.swift
@@ -1,0 +1,60 @@
+//
+//  JoinTripDataService.swift
+//  DooRiBon
+//
+//  Created by taehy.k on 2021/07/13.
+//
+
+import Foundation
+
+import Alamofire
+
+struct JoinTripDataService {
+    // MARK: - 싱글톤 변수
+    
+    static let shared = JoinTripDataService()
+    
+    // MARK: - API 요청 함수
+    
+    func getTripInfoWithInviteCode(completion: @escaping (NetworkResult<Any>)->()) {
+        
+        let url: String = APIConstants.inviteCodeURL            // URL
+        let header: HTTPHeaders = NetworkInfo.headerWithToken   // Headers
+        
+        let dataRequest = AF.request(url,
+                                     method: .get,
+                                     encoding: JSONEncoding.default,
+                                     headers: header)
+        
+        dataRequest.responseData { (response) in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.value else { return }
+                
+                print("😁 \(statusCode)")
+                print("💽 \(data)")
+                    
+                completion(judgeStatus(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+                completion(.networkFail)
+            }
+        }
+    }
+    
+    // MARK: - Judge Function
+    
+    private func judgeStatus(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(JoinTripData.self, from: data) else {return .pathErr}
+        
+        switch status {
+        case 200: return .success(decodedData)
+        case 400..<500: return .requestErr(decodedData)
+        case 500: return .serverErr
+        default: return .networkFail
+        }
+    }
+}

--- a/DooRiBon/Podfile
+++ b/DooRiBon/Podfile
@@ -10,4 +10,5 @@ target 'DooRiBon' do
   pod 'SnapKit', '~> 5.0.0'
   pod 'FSCalendar', :git => 'https://github.com/hyejinL/FSCalendar.git', :branch => 'dooribun'
    # Pods for FSCalendarPractice
+  pod 'Kingfisher', '~> 6.0'
 end

--- a/DooRiBon/Podfile.lock
+++ b/DooRiBon/Podfile.lock
@@ -1,16 +1,19 @@
 PODS:
   - Alamofire (5.4.1)
   - FSCalendar (2.8.3)
+  - Kingfisher (6.1.0)
   - SnapKit (5.0.1)
 
 DEPENDENCIES:
   - Alamofire (~> 5.4)
   - FSCalendar (from `https://github.com/hyejinL/FSCalendar.git`, branch `dooribun`)
+  - Kingfisher (~> 6.0)
   - SnapKit (~> 5.0.0)
 
 SPEC REPOS:
   trunk:
     - Alamofire
+    - Kingfisher
     - SnapKit
 
 EXTERNAL SOURCES:
@@ -26,8 +29,9 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Alamofire: 2291f7d21ca607c491dd17642e5d40fdcda0e65c
   FSCalendar: ed63fee7df375e34340c1236308fdbfc568d26ac
+  Kingfisher: f5d8d60a0ef3edd642fd781bae60918599901aff
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
 
-PODFILE CHECKSUM: 87de49301bd0cc7130c891b19e10db661ed7c0c6
+PODFILE CHECKSUM: 7e5ab95ff915890445e2ab89f00d4d8b8873b433
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
## 🌴 PR 요약
참여코드 입력뷰 서버 연결을 완료했습니다.
다음화면이 현재 없어서 데이터를 넘기지는 못하였고, 서버에서 넘어오는 것은 확인했습니다.

🌱 작업한 브랜치
- feature/#81

🌱 작업한 내용
- 참여코드 숫자+문자 입력 가능하도록 UI 수정
- 참여코드 6자리 뽑아내기 (string형태로)
- 모두 입력해주세요 버튼 클릭 시 API 요청

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|png|<img width="1560" alt="스크린샷 2021-07-13 오후 5 21 43" src="https://user-images.githubusercontent.com/61109660/125418028-93f2dc59-b3be-4ae2-913e-2ba6b152ab6f.png">|

## 📮 관련 이슈
- Resolved: #81