### PR TITLE
[FIX] #84 - 여행 성향 화면 하나씩만 선택되도록 수정

### DIFF
--- a/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
+++ b/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0A1BD3BA268E193E00702EC5 /* PagerTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1BD3B9268E193E00702EC5 /* PagerTab.swift */; };
 		0A1BD3BC268E1C6C00702EC5 /* PagerTabSampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1BD3BB268E1C6C00702EC5 /* PagerTabSampleViewController.swift */; };
 		0A1BD3C0268E1E3D00702EC5 /* PagerTabSampleViewControllerStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A1BD3BF268E1E3D00702EC5 /* PagerTabSampleViewControllerStoryboard.storyboard */; };
+		0A278237269CAB410001591F /* AnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A278236269CAB410001591F /* AnswerView.swift */; };
+		0A278239269CAB490001591F /* AnswerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A278238269CAB490001591F /* AnswerView.xib */; };
 		0A88A010269493E000A4EBD0 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A88A00F269493E000A4EBD0 /* PopupView.swift */; };
 		0A88A0122694941F00A4EBD0 /* PopupView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A88A0112694941E00A4EBD0 /* PopupView.xib */; };
 		0A88A0142694A61800A4EBD0 /* UIApplication+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A88A0132694A61800A4EBD0 /* UIApplication+Extension.swift */; };
@@ -120,6 +122,8 @@
 		0A1BD3B9268E193E00702EC5 /* PagerTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagerTab.swift; sourceTree = "<group>"; };
 		0A1BD3BB268E1C6C00702EC5 /* PagerTabSampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagerTabSampleViewController.swift; sourceTree = "<group>"; };
 		0A1BD3BF268E1E3D00702EC5 /* PagerTabSampleViewControllerStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PagerTabSampleViewControllerStoryboard.storyboard; sourceTree = "<group>"; };
+		0A278236269CAB410001591F /* AnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerView.swift; sourceTree = "<group>"; };
+		0A278238269CAB490001591F /* AnswerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AnswerView.xib; sourceTree = "<group>"; };
 		0A88A00F269493E000A4EBD0 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		0A88A0112694941E00A4EBD0 /* PopupView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PopupView.xib; sourceTree = "<group>"; };
 		0A88A0132694A61800A4EBD0 /* UIApplication+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extension.swift"; sourceTree = "<group>"; };
@@ -293,6 +297,8 @@
 			children = (
 				392FCFB9269C2DE700981069 /* OutPopupView.swift */,
 				392FCFBB269C2DF900981069 /* OutPopupView.xib */,
+				0A278236269CAB410001591F /* AnswerView.swift */,
+				0A278238269CAB490001591F /* AnswerView.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -895,6 +901,7 @@
 				407E640A269A139E007C8081 /* MemberStart.xib in Resources */,
 				39EAC4B32692E0FA00114734 /* StartTripViewController.xib in Resources */,
 				0A88A0122694941F00A4EBD0 /* PopupView.xib in Resources */,
+				0A278239269CAB490001591F /* AnswerView.xib in Resources */,
 				BDCC36802695DEAA009AE274 /* NoDataTableViewCell.xib in Resources */,
 				BD39D4FC268DE80D004714B6 /* SpoqaHanSansNeo-Regular.ttf in Resources */,
 				399C700C269B27840017069C /* QuestionCell.xib in Resources */,
@@ -979,6 +986,7 @@
 				BD1725D7269D78F7000FB89B /* JoinTripDataService.swift in Sources */,
 				3975958D269B569D008E8360 /* TestChoiceViewController.swift in Sources */,
 				BD0AD6222693653D0033DAD8 /* BoardViewController.swift in Sources */,
+				0A278237269CAB410001591F /* AnswerView.swift in Sources */,
 				408D1ADF26957D8F00BBC454 /* CalendarCell.swift in Sources */,
 				BD75C2E7268B52BD00C4F233 /* MainViewController.swift in Sources */,
 				BDA5626926994E2100616CBF /* DummyDataModel.swift in Sources */,

--- a/DooRiBon/DooRiBon/Sources/Main/StyleTest/Cells/AnswerCollectionViewCell.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/StyleTest/Cells/AnswerCollectionViewCell.swift
@@ -7,113 +7,63 @@
 
 import UIKit
 
+protocol AnswerCollectionViewCellDelegate: NSObject {
+    func didSelectedAnswer(_ index: Int)
+}
+
 class AnswerCollectionViewCell: UICollectionViewCell {
     static let identifier: String = "AnswerCollectionViewCell"
-    
-    @IBOutlet weak var firstAnswerView: UIView!
-    @IBOutlet weak var secondAnswerView: UIView!
-    @IBOutlet weak var thirdAnswerView: UIView!
-    @IBOutlet weak var fourthAnswerView: UIView!
-    
-    @IBOutlet weak var firstCircle: UIView!
-    @IBOutlet weak var secondCircle: UIView!
-    @IBOutlet weak var thirdCircle: UIView!
-    @IBOutlet weak var fourthCircle: UIView!
-    
-    @IBOutlet weak var firstNumberLabel: UILabel!
-    @IBOutlet weak var secondNumberLabel: UILabel!
-    @IBOutlet weak var thirdNumberLabel: UILabel!
-    @IBOutlet weak var fourthNumberLabel: UILabel!
-    
-    @IBOutlet weak var firstAnswerLabel: UILabel!
-    @IBOutlet weak var secondAnswerLabel: UILabel!
-    @IBOutlet weak var thirdAnswerLabel: UILabel!
-    @IBOutlet weak var fourthAnswerLabel: UILabel!
-    
+
+    @IBOutlet weak var firstAnswerView: AnswerView!
+    @IBOutlet weak var secondAnswerView: AnswerView!
+    @IBOutlet weak var thirdAnswerView: AnswerView!
+    @IBOutlet weak var fourthAnswerView: AnswerView!
+
+    weak var delegate: AnswerCollectionViewCellDelegate?
+
     override func awakeFromNib() {
         super.awakeFromNib()
-        makeCircleView()
+        firstAnswerView.delegate = self
+        secondAnswerView.delegate = self
+        thirdAnswerView.delegate = self
+        fourthAnswerView.delegate = self
     }
-    
-    @IBAction func answerButtonClicked(_ sender: UIButton) {
-        self.isSelected = !self.isSelected
-        switch sender.tag {
-        case 0:
-            if isSelected {
-                firstAnswerView.backgroundColor = UIColor(named: "pointBlue")
-                firstCircle.backgroundColor = UIColor(named: "white9")
-                firstNumberLabel.textColor = UIColor(named: "pointBlue")
-                firstAnswerLabel.textColor = UIColor(named: "white9")
-            }
-            else {
-                firstAnswerView.backgroundColor = UIColor(named: "white9")
-                firstCircle.backgroundColor = UIColor(named: "subOrange1")
-                firstNumberLabel.textColor = UIColor(named: "white9")
-                firstAnswerLabel.textColor = UIColor(named: "black3")
-            }
-        case 1:
-            if isSelected {
-                secondAnswerView.backgroundColor = UIColor(named: "pointBlue")
-                secondCircle.backgroundColor = UIColor(named: "white9")
-                secondNumberLabel.textColor = UIColor(named: "pointBlue")
-                secondAnswerLabel.textColor = UIColor(named: "white9")
-            }
-            else {
-                secondAnswerView.backgroundColor = UIColor(named: "white9")
-                secondCircle.backgroundColor = UIColor(named: "subOrange1")
-                secondNumberLabel.textColor = UIColor(named: "white9")
-                secondAnswerLabel.textColor = UIColor(named: "black3")
-            }
-        case 2:
-            if isSelected {
-                thirdAnswerView.backgroundColor = UIColor(named: "pointBlue")
-                thirdCircle.backgroundColor = UIColor(named: "white9")
-                thirdNumberLabel.textColor = UIColor(named: "pointBlue")
-                thirdAnswerLabel.textColor = UIColor(named: "white9")
-            }
-            else {
-                thirdAnswerView.backgroundColor = UIColor(named: "white9")
-                thirdCircle.backgroundColor = UIColor(named: "subOrange1")
-                thirdNumberLabel.textColor = UIColor(named: "white9")
-                thirdAnswerLabel.textColor = UIColor(named: "black3")
-            }
-        case 3:
-            if isSelected {
-                fourthAnswerView.backgroundColor = UIColor(named: "pointBlue")
-                fourthCircle.backgroundColor = UIColor(named: "white9")
-                fourthNumberLabel.textColor = UIColor(named: "pointBlue")
-                fourthAnswerLabel.textColor = UIColor(named: "white9")
-            }
-            else {
-                fourthAnswerView.backgroundColor = UIColor(named: "white9")
-                fourthCircle.backgroundColor = UIColor(named: "subOrange1")
-                fourthNumberLabel.textColor = UIColor(named: "white9")
-                fourthAnswerLabel.textColor = UIColor(named: "black3")
-            }
-        default:
-            return
-        }
-        
-        
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        firstAnswerView.isSelected = false
+        secondAnswerView.isSelected = false
+        thirdAnswerView.isSelected = false
+        fourthAnswerView.isSelected = false
     }
-    
+
     func setData(answer1: String,
                  answer2: String,
                  answer3: String,
                  answer4: String)
     {
-        firstAnswerLabel.text = answer1
-        secondAnswerLabel.text = answer2
-        thirdAnswerLabel.text = answer3
-        fourthAnswerLabel.text = answer4
+        firstAnswerView.answerLabel.text = answer1
+        secondAnswerView.answerLabel.text = answer2
+        thirdAnswerView.answerLabel.text = answer3
+        fourthAnswerView.answerLabel.text = answer4
     }
-    
-    func makeCircleView()
-    {
-        firstCircle.layer.cornerRadius = firstCircle.frame.height / 2
-        secondCircle.layer.cornerRadius = secondCircle.frame.height / 2
-        thirdCircle.layer.cornerRadius = thirdCircle.frame.height / 2
-        fourthCircle.layer.cornerRadius = fourthCircle.frame.height / 2
+}
+
+extension AnswerCollectionViewCell: AnswerViewDelegate {
+    func answerView(_ answerView: AnswerView, didSelected isSelected: Bool) {
+        let views: [AnswerView] = [
+            firstAnswerView,
+            secondAnswerView,
+            thirdAnswerView,
+            fourthAnswerView
+        ]
+
+        for (i, view) in views.enumerated() {
+            if view === answerView {
+                delegate?.didSelectedAnswer(i)
+            } else {
+                view.isSelected = false
+            }
+        }
     }
-    
 }

--- a/DooRiBon/DooRiBon/Sources/Main/StyleTest/TestChoiceStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Main/StyleTest/TestChoiceStoryboard.storyboard
@@ -17,9 +17,6 @@
         <array key="SpoqaHanSansNeo-Medium.ttf">
             <string>SpoqaHanSansNeo-Medium</string>
         </array>
-        <array key="SpoqaHanSansNeo-Regular.ttf">
-            <string>SpoqaHanSansNeo-Regular</string>
-        </array>
     </customFonts>
     <scenes>
         <!--TestChoiceViewController-->
@@ -72,10 +69,10 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="nhK-1x-pcV">
-                                <rect key="frame" x="18" y="224" width="339" height="240"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <rect key="frame" x="18" y="224" width="339" height="260"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="240" id="hJI-fF-s9D"/>
+                                    <constraint firstAttribute="height" constant="260" id="LqI-tc-82Z"/>
                                 </constraints>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="HMf-j3-qfG">
                                     <size key="itemSize" width="202" height="232"/>
@@ -85,7 +82,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AnswerCollectionViewCell" id="DCL-5S-RsK" customClass="AnswerCollectionViewCell" customModule="DooRiBon" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="339" height="240"/>
+                                        <rect key="frame" x="0.0" y="10" width="339" height="240"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Eve-oA-lTw">
                                             <rect key="frame" x="0.0" y="0.0" width="339" height="240"/>
@@ -94,247 +91,39 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8GV-AO-iSv">
                                                     <rect key="frame" x="0.0" y="0.0" width="339" height="240"/>
                                                     <subviews>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hMS-Sz-TrD">
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hMS-Sz-TrD" customClass="AnswerView" customModule="DooRiBon" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="339" height="54"/>
-                                                            <subviews>
-                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xnx-Ca-UF8">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="339" height="54"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                            <real key="value" value="8"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                    <connections>
-                                                                        <action selector="answerButtonClicked:" destination="DCL-5S-RsK" eventType="touchUpInside" id="Nj2-uV-s1h"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vUK-Nm-LrV">
-                                                                    <rect key="frame" x="10" y="15" width="24" height="24"/>
-                                                                    <color key="backgroundColor" name="subOrange1"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="24" id="K8Q-GV-GMm"/>
-                                                                        <constraint firstAttribute="width" secondItem="vUK-Nm-LrV" secondAttribute="height" multiplier="1:1" id="rxv-wV-xoa"/>
-                                                                    </constraints>
-                                                                </view>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="urE-xX-9zd">
-                                                                    <rect key="frame" x="17.666666666666668" y="18" width="8.6666666666666679" height="18"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="18" id="zbc-vo-KvR"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
-                                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="djT-cr-oZw">
-                                                                    <rect key="frame" x="41" y="17" width="287" height="22"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="287" id="4ys-Mw-26i"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="13"/>
-                                                                    <color key="textColor" name="black3"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                            <constraints>
-                                                                <constraint firstItem="urE-xX-9zd" firstAttribute="centerX" secondItem="vUK-Nm-LrV" secondAttribute="centerX" id="4kx-ch-D2v"/>
-                                                                <constraint firstItem="djT-cr-oZw" firstAttribute="leading" secondItem="vUK-Nm-LrV" secondAttribute="trailing" constant="7" id="6g1-jt-D3I"/>
-                                                                <constraint firstAttribute="trailing" secondItem="xnx-Ca-UF8" secondAttribute="trailing" id="7Qy-SN-CK8"/>
-                                                                <constraint firstItem="vUK-Nm-LrV" firstAttribute="leading" secondItem="hMS-Sz-TrD" secondAttribute="leading" constant="10" id="EPH-aR-Mw4"/>
-                                                                <constraint firstAttribute="bottom" secondItem="djT-cr-oZw" secondAttribute="bottom" constant="15" id="IuB-4Z-Noa"/>
-                                                                <constraint firstItem="urE-xX-9zd" firstAttribute="centerY" secondItem="vUK-Nm-LrV" secondAttribute="centerY" id="PEY-fs-Fp6"/>
-                                                                <constraint firstItem="vUK-Nm-LrV" firstAttribute="centerY" secondItem="hMS-Sz-TrD" secondAttribute="centerY" id="TKH-wJ-jaD"/>
-                                                                <constraint firstItem="djT-cr-oZw" firstAttribute="top" secondItem="hMS-Sz-TrD" secondAttribute="top" constant="17" id="TkS-GC-Yks"/>
-                                                                <constraint firstAttribute="bottom" secondItem="xnx-Ca-UF8" secondAttribute="bottom" id="i9q-6V-EjE"/>
-                                                                <constraint firstItem="xnx-Ca-UF8" firstAttribute="top" secondItem="hMS-Sz-TrD" secondAttribute="top" id="miu-gj-AKh"/>
-                                                                <constraint firstItem="xnx-Ca-UF8" firstAttribute="leading" secondItem="hMS-Sz-TrD" secondAttribute="leading" id="ywU-dV-kKN"/>
-                                                            </constraints>
                                                             <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                    <real key="value" value="8"/>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="number">
+                                                                    <integer key="value" value="1"/>
                                                                 </userDefinedRuntimeAttribute>
                                                             </userDefinedRuntimeAttributes>
                                                         </view>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mqv-hC-rEX">
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mqv-hC-rEX" customClass="AnswerView" customModule="DooRiBon" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="62" width="339" height="54"/>
-                                                            <subviews>
-                                                                <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G7c-0p-kwq">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="339" height="54"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                            <real key="value" value="8"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                    <connections>
-                                                                        <action selector="answerButtonClicked:" destination="DCL-5S-RsK" eventType="touchUpInside" id="Ww1-3y-JRO"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="52I-xi-B4S">
-                                                                    <rect key="frame" x="10" y="15" width="24" height="24"/>
-                                                                    <color key="backgroundColor" name="subOrange1"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" secondItem="52I-xi-B4S" secondAttribute="height" multiplier="1:1" id="JhK-dE-Jlq"/>
-                                                                        <constraint firstAttribute="width" constant="24" id="W67-7s-IGh"/>
-                                                                    </constraints>
-                                                                </view>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Ev-vV-6HZ">
-                                                                    <rect key="frame" x="17.666666666666668" y="18" width="8.6666666666666679" height="18"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="18" id="HKV-Z9-GlF"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
-                                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FpQ-mZ-gz2">
-                                                                    <rect key="frame" x="41" y="17" width="287" height="22"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="287" id="WaH-CB-zyY"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="13"/>
-                                                                    <color key="textColor" name="black3"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="bottom" secondItem="FpQ-mZ-gz2" secondAttribute="bottom" constant="15" id="4dR-m2-IhI"/>
-                                                                <constraint firstItem="G7c-0p-kwq" firstAttribute="leading" secondItem="Mqv-hC-rEX" secondAttribute="leading" id="7aZ-K9-zkD"/>
-                                                                <constraint firstItem="52I-xi-B4S" firstAttribute="centerY" secondItem="Mqv-hC-rEX" secondAttribute="centerY" id="8TL-WO-yAN"/>
-                                                                <constraint firstAttribute="bottom" secondItem="G7c-0p-kwq" secondAttribute="bottom" id="BIF-Dq-UZ8"/>
-                                                                <constraint firstItem="52I-xi-B4S" firstAttribute="leading" secondItem="Mqv-hC-rEX" secondAttribute="leading" constant="10" id="BKC-PI-8ar"/>
-                                                                <constraint firstItem="3Ev-vV-6HZ" firstAttribute="centerY" secondItem="52I-xi-B4S" secondAttribute="centerY" id="Bu2-Xd-3c8"/>
-                                                                <constraint firstItem="FpQ-mZ-gz2" firstAttribute="top" secondItem="Mqv-hC-rEX" secondAttribute="top" constant="17" id="Jo3-Iz-fRx"/>
-                                                                <constraint firstItem="FpQ-mZ-gz2" firstAttribute="leading" secondItem="52I-xi-B4S" secondAttribute="trailing" constant="7" id="JuQ-OC-OwQ"/>
-                                                                <constraint firstItem="G7c-0p-kwq" firstAttribute="top" secondItem="Mqv-hC-rEX" secondAttribute="top" id="ZRm-Ee-iFm"/>
-                                                                <constraint firstItem="3Ev-vV-6HZ" firstAttribute="centerX" secondItem="52I-xi-B4S" secondAttribute="centerX" id="bt7-RL-K3V"/>
-                                                                <constraint firstAttribute="trailing" secondItem="G7c-0p-kwq" secondAttribute="trailing" id="btR-Cg-asq"/>
-                                                            </constraints>
                                                             <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                    <real key="value" value="8"/>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="number">
+                                                                    <integer key="value" value="2"/>
                                                                 </userDefinedRuntimeAttribute>
                                                             </userDefinedRuntimeAttributes>
                                                         </view>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8JN-8m-Gdl">
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8JN-8m-Gdl" customClass="AnswerView" customModule="DooRiBon" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="124" width="339" height="54"/>
-                                                            <subviews>
-                                                                <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uTQ-PV-ZFN">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="339" height="54"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                            <real key="value" value="8"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                    <connections>
-                                                                        <action selector="answerButtonClicked:" destination="DCL-5S-RsK" eventType="touchUpInside" id="5zl-7m-YXq"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TRf-gq-viL">
-                                                                    <rect key="frame" x="10" y="15" width="24" height="24"/>
-                                                                    <color key="backgroundColor" name="subOrange1"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="24" id="or1-Z5-J6m"/>
-                                                                        <constraint firstAttribute="width" secondItem="TRf-gq-viL" secondAttribute="height" multiplier="1:1" id="t09-cH-ota"/>
-                                                                    </constraints>
-                                                                </view>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hlb-0K-eCu">
-                                                                    <rect key="frame" x="17.666666666666668" y="18" width="8.6666666666666679" height="18"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="18" id="d2V-dc-UBr"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
-                                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AgQ-Hk-DOW">
-                                                                    <rect key="frame" x="41" y="17" width="287" height="22"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="287" id="nIU-ue-EZT"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="13"/>
-                                                                    <color key="textColor" name="black3"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="trailing" secondItem="uTQ-PV-ZFN" secondAttribute="trailing" id="8ot-0h-JXW"/>
-                                                                <constraint firstItem="hlb-0K-eCu" firstAttribute="centerY" secondItem="TRf-gq-viL" secondAttribute="centerY" id="GN5-u1-Gr7"/>
-                                                                <constraint firstItem="TRf-gq-viL" firstAttribute="leading" secondItem="8JN-8m-Gdl" secondAttribute="leading" constant="10" id="NUW-P3-Mpc"/>
-                                                                <constraint firstItem="uTQ-PV-ZFN" firstAttribute="leading" secondItem="8JN-8m-Gdl" secondAttribute="leading" id="P1w-IH-QPc"/>
-                                                                <constraint firstAttribute="bottom" secondItem="uTQ-PV-ZFN" secondAttribute="bottom" id="cLb-7j-yHi"/>
-                                                                <constraint firstAttribute="bottom" secondItem="AgQ-Hk-DOW" secondAttribute="bottom" constant="15" id="qlk-gV-qkM"/>
-                                                                <constraint firstItem="hlb-0K-eCu" firstAttribute="centerX" secondItem="TRf-gq-viL" secondAttribute="centerX" id="sMg-2R-YeH"/>
-                                                                <constraint firstItem="uTQ-PV-ZFN" firstAttribute="top" secondItem="8JN-8m-Gdl" secondAttribute="top" id="uPp-fV-TBd"/>
-                                                                <constraint firstItem="AgQ-Hk-DOW" firstAttribute="leading" secondItem="TRf-gq-viL" secondAttribute="trailing" constant="7" id="wdW-Wx-sPr"/>
-                                                                <constraint firstItem="AgQ-Hk-DOW" firstAttribute="top" secondItem="8JN-8m-Gdl" secondAttribute="top" constant="17" id="whs-WM-ihW"/>
-                                                                <constraint firstItem="TRf-gq-viL" firstAttribute="centerY" secondItem="8JN-8m-Gdl" secondAttribute="centerY" id="wz1-r8-bSw"/>
-                                                            </constraints>
                                                             <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                    <real key="value" value="8"/>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="number">
+                                                                    <integer key="value" value="3"/>
                                                                 </userDefinedRuntimeAttribute>
                                                             </userDefinedRuntimeAttributes>
                                                         </view>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="61O-dS-9sr">
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="61O-dS-9sr" customClass="AnswerView" customModule="DooRiBon" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="186" width="339" height="54"/>
-                                                            <subviews>
-                                                                <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15J-hc-Qiw">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="339" height="54"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                            <real key="value" value="8"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                    <connections>
-                                                                        <action selector="answerButtonClicked:" destination="DCL-5S-RsK" eventType="touchUpInside" id="MLQ-HR-7Ab"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CIO-yL-K5I">
-                                                                    <rect key="frame" x="10" y="15" width="24" height="24"/>
-                                                                    <color key="backgroundColor" name="subOrange1"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="24" id="Jte-f1-2Ga"/>
-                                                                        <constraint firstAttribute="width" secondItem="CIO-yL-K5I" secondAttribute="height" multiplier="1:1" id="pgt-HV-Ejw"/>
-                                                                    </constraints>
-                                                                </view>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQY-4s-Tcf">
-                                                                    <rect key="frame" x="17.666666666666668" y="18" width="8.6666666666666679" height="18"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="18" id="ugT-Fy-4ss"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
-                                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zwX-ul-Fti">
-                                                                    <rect key="frame" x="41" y="17" width="287" height="22"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="287" id="caD-Tw-G0y"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="13"/>
-                                                                    <color key="textColor" name="black3"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                            <constraints>
-                                                                <constraint firstItem="hQY-4s-Tcf" firstAttribute="centerX" secondItem="CIO-yL-K5I" secondAttribute="centerX" id="1tR-xG-tGu"/>
-                                                                <constraint firstAttribute="bottom" secondItem="15J-hc-Qiw" secondAttribute="bottom" id="M2G-wl-6YB"/>
-                                                                <constraint firstItem="zwX-ul-Fti" firstAttribute="leading" secondItem="CIO-yL-K5I" secondAttribute="trailing" constant="7" id="MeQ-g2-ftE"/>
-                                                                <constraint firstItem="zwX-ul-Fti" firstAttribute="top" secondItem="61O-dS-9sr" secondAttribute="top" constant="17" id="ONL-pz-2Fj"/>
-                                                                <constraint firstItem="15J-hc-Qiw" firstAttribute="leading" secondItem="61O-dS-9sr" secondAttribute="leading" id="R30-4E-b3N"/>
-                                                                <constraint firstAttribute="trailing" secondItem="15J-hc-Qiw" secondAttribute="trailing" id="Tni-TQ-gYd"/>
-                                                                <constraint firstItem="hQY-4s-Tcf" firstAttribute="centerY" secondItem="CIO-yL-K5I" secondAttribute="centerY" id="Wd3-uy-BTG"/>
-                                                                <constraint firstItem="CIO-yL-K5I" firstAttribute="leading" secondItem="61O-dS-9sr" secondAttribute="leading" constant="10" id="iTx-la-D2p"/>
-                                                                <constraint firstItem="CIO-yL-K5I" firstAttribute="centerY" secondItem="61O-dS-9sr" secondAttribute="centerY" id="rgK-fV-ehi"/>
-                                                                <constraint firstAttribute="bottom" secondItem="zwX-ul-Fti" secondAttribute="bottom" constant="15" id="ttU-aX-B8t"/>
-                                                                <constraint firstItem="15J-hc-Qiw" firstAttribute="top" secondItem="61O-dS-9sr" secondAttribute="top" id="xRA-7f-f1p"/>
-                                                            </constraints>
                                                             <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                    <real key="value" value="8"/>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="number">
+                                                                    <integer key="value" value="4"/>
                                                                 </userDefinedRuntimeAttribute>
                                                             </userDefinedRuntimeAttributes>
                                                         </view>
@@ -352,22 +141,10 @@
                                         <color key="backgroundColor" name="backgroundBlue"/>
                                         <size key="customSize" width="339" height="240"/>
                                         <connections>
-                                            <outlet property="firstAnswerLabel" destination="djT-cr-oZw" id="vCE-wP-r2X"/>
-                                            <outlet property="firstAnswerView" destination="hMS-Sz-TrD" id="cqB-5b-Cjk"/>
-                                            <outlet property="firstCircle" destination="vUK-Nm-LrV" id="Azk-bI-gAy"/>
-                                            <outlet property="firstNumberLabel" destination="urE-xX-9zd" id="XBU-XD-H9k"/>
-                                            <outlet property="fourthAnswerLabel" destination="zwX-ul-Fti" id="xJD-MB-bbF"/>
-                                            <outlet property="fourthAnswerView" destination="61O-dS-9sr" id="78J-Qv-Izz"/>
-                                            <outlet property="fourthCircle" destination="CIO-yL-K5I" id="T9Y-5d-Qay"/>
-                                            <outlet property="fourthNumberLabel" destination="hQY-4s-Tcf" id="THa-kh-x5k"/>
-                                            <outlet property="secondAnswerLabel" destination="FpQ-mZ-gz2" id="Upu-i6-dcf"/>
-                                            <outlet property="secondAnswerView" destination="Mqv-hC-rEX" id="N5t-sp-MKV"/>
-                                            <outlet property="secondCircle" destination="52I-xi-B4S" id="LFi-qQ-ReE"/>
-                                            <outlet property="secondNumberLabel" destination="3Ev-vV-6HZ" id="kFX-SD-in2"/>
-                                            <outlet property="thirdAnswerLabel" destination="AgQ-Hk-DOW" id="ZXA-Pp-Zah"/>
-                                            <outlet property="thirdAnswerView" destination="8JN-8m-Gdl" id="ayb-m6-rfm"/>
-                                            <outlet property="thirdCircle" destination="TRf-gq-viL" id="dMU-MH-FmD"/>
-                                            <outlet property="thirdNumberLabel" destination="hlb-0K-eCu" id="j9F-E3-Uid"/>
+                                            <outlet property="firstAnswerView" destination="hMS-Sz-TrD" id="Hnz-16-qcy"/>
+                                            <outlet property="fourthAnswerView" destination="61O-dS-9sr" id="jeg-Au-s4y"/>
+                                            <outlet property="secondAnswerView" destination="Mqv-hC-rEX" id="GJH-ED-Kvs"/>
+                                            <outlet property="thirdAnswerView" destination="8JN-8m-Gdl" id="3iL-Mt-QJC"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -476,9 +253,6 @@
         <namedColor name="black1">
             <color red="0.125" green="0.125" blue="0.125" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <namedColor name="black3">
-            <color red="0.27799999713897705" green="0.29800000786781311" blue="0.31799998879432678" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <namedColor name="gray4">
             <color red="0.36899998784065247" green="0.39599999785423279" blue="0.41999998688697815" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
@@ -490,9 +264,6 @@
         </namedColor>
         <namedColor name="pointOrange">
             <color red="1" green="0.48199999332427979" blue="0.31799998879432678" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="subOrange1">
-            <color red="1" green="0.60000002384185791" blue="0.51800000667572021" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="white9">
             <color red="0.99199998378753662" green="0.99599999189376831" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/DooRiBon/DooRiBon/Sources/Main/StyleTest/TestChoiceViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/StyleTest/TestChoiceViewController.swift
@@ -18,6 +18,7 @@ class TestChoiceViewController: UIViewController {
     @IBOutlet weak var indicatorBar: UIView!
     
     private var answerList: [AnswerDataModel] = []
+    private lazy var answers: [Int] = Array(repeating: 0, count: answerList.count)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,19 +26,35 @@ class TestChoiceViewController: UIViewController {
         navigationController?.navigationBar.isHidden = true
         
         serAnswerList()
+        updateQuestion(0)
         answerCollectionView.delegate = self
         answerCollectionView.dataSource = self
+
+        answerCollectionView.isScrollEnabled = false
     }
-    
+
     @IBAction func previousButtonClicked(_ sender: Any) {
-        
+        guard let cell = answerCollectionView.visibleCells.first,
+           let currentNumber = answerCollectionView.indexPath(for: cell)?.item else {
+            return
+        }
+        let previousItem = max(currentNumber - 1, 0)
+        answerCollectionView.scrollToItem(at: IndexPath(item: previousItem, section: 0), at: .left, animated: true)
+        updateQuestion(previousItem)
     }
     
     @IBAction func nextButtonClicked(_ sender: Any) {
-        // answerCollectionView.scrollToItem(at: IndexPath, at: <#T##UICollectionView.ScrollPosition#>, animated: <#T##Bool#>)
+        guard let cell = answerCollectionView.visibleCells.first,
+           let currentNumber = answerCollectionView.indexPath(for: cell)?.item else {
+            return
+        }
+        let nextItem = min(currentNumber + 1, answerList.count - 1)
+        answerCollectionView.scrollToItem(at: IndexPath(item: nextItem, section: 0), at: .left, animated: true)
+        updateQuestion(nextItem)
     }
     
     @IBAction func outTestButtonClicked(_ sender: Any) {
+        // FIXME: 공통 popup으로 바꾸세요.
         OutPopupView.loadFromXib()
             .setTitle("정말 나가시겠습니까?")
             .setDescription("""
@@ -69,8 +86,38 @@ class TestChoiceViewController: UIViewController {
             AnswerDataModel(answer1: "사람들이 많이 가는 유명한 장소 위주로 다닐래", answer2: "랜드마크 몇 군데만 가고 나머지는 마음대로 다닐래", answer3: "아무도 안 가본 새로운 장소를 찾아보고 싶어", answer4: "함께 하는 사람들이 가자는 대로 갈래")
         ])
     }
+
+    func updateQuestion(_ currentNumber: Int) {
+        self.questionNumberLabel.text = "Q\(currentNumber + 1)"
+        // 질문 내용 변경
+        switch currentNumber {
+        case 0:
+            self.questionLabel.text = "계획을 세울 때 나는?"
+        case 1:
+            self.questionLabel.text = "한 장소에서 다른 장소로 이동할 때 나는?"
+        case 2:
+            self.questionLabel.text = "내가 원하는 여행 스타일은"
+        case 3:
+            self.questionLabel.text = "멋진 풍경이 내 눈 앞에 펼쳐졌을 때 나는?"
+        case 4:
+            self.questionLabel.text = "가려고 했던 식당이 문을 닫았을 때 나는?"
+        case 5:
+            self.questionLabel.text = "내가 더 많은 시간을 보내고 싶은 곳은?"
+        case 6:
+            self.questionLabel.text = "일행과 서로 가고 싶은 곳이 다를 때는?"
+        case 7:
+            self.questionLabel.text = "일행과 서로 가고 싶은 곳이 다를 때는?"
+        case 8:
+            self.questionLabel.text = "다른 사람들이 말을 걸어왔을 때 나는?"
+        case 9:
+            self.questionLabel.text = "방문할 장소를 선택할 때 나는?"
+        default:
+            self.questionLabel.text = " "
+        }
+    }
     
     // MARK: - 컬렉션뷰 인덱스에 따른 변화
+    // FIXME: MainViewController 처럼 바꾸기
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         for cell in answerCollectionView.visibleCells {
             if let row = answerCollectionView.indexPath(for: cell)?.item {
@@ -79,43 +126,6 @@ class TestChoiceViewController: UIViewController {
                 let totalWidth = backgroundView.frame.width
                 UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut) {
                     self.indicatorBar.frame.origin.x = totalWidth * (CGFloat(row)/10)
-                }
-            
-                // 질문 내용 변경
-                switch row {
-                case 0:
-                    self.questionNumberLabel.text = "Q1"
-                    self.questionLabel.text = "계획을 세울 때 나는?"
-                case 1:
-                    self.questionNumberLabel.text = "Q2"
-                    self.questionLabel.text = "한 장소에서 다른 장소로 이동할 때 나는?"
-                case 2:
-                    self.questionNumberLabel.text = "Q3"
-                    self.questionLabel.text = "내가 원하는 여행 스타일은"
-                case 3:
-                    self.questionNumberLabel.text = "Q4"
-                    self.questionLabel.text = "멋진 풍경이 내 눈 앞에 펼쳐졌을 때 나는?"
-                case 4:
-                    self.questionNumberLabel.text = "Q5"
-                    self.questionLabel.text = "가려고 했던 식당이 문을 닫았을 때 나는?"
-                case 5:
-                    self.questionNumberLabel.text = "Q6"
-                    self.questionLabel.text = "내가 더 많은 시간을 보내고 싶은 곳은?"
-                case 6:
-                    self.questionNumberLabel.text = "Q7"
-                    self.questionLabel.text = "일행과 서로 가고 싶은 곳이 다를 때는?"
-                case 7:
-                    self.questionNumberLabel.text = "Q8"
-                    self.questionLabel.text = "일행과 서로 가고 싶은 곳이 다를 때는?"
-                case 8:
-                    self.questionNumberLabel.text = "Q9"
-                    self.questionLabel.text = "다른 사람들이 말을 걸어왔을 때 나는?"
-                case 9:
-                    self.questionNumberLabel.text = "Q10"
-                    self.questionLabel.text = "방문할 장소를 선택할 때 나는?"
-                default:
-                    self.questionNumberLabel.text = " "
-                    self.questionLabel.text = " "
                 }
             }
         }
@@ -154,9 +164,9 @@ extension TestChoiceViewController: UICollectionViewDelegateFlowLayout
         
         let width = UIScreen.main.bounds.width      // 현재 사용하는 기기의 width를 가져와서 저장
         
-        let cellWidth = width * (339/375)            // 제플린에서의 비율만큼 곱해서 width를 결정
+        let cellWidth = width - 18 * 2
         let cellHeight = cellWidth * (240/339)        // 제플린에서의 비율만큼 곱해서 height를 결정
-        
+
         return CGSize(width: cellWidth, height: cellHeight)     // 정해진 가로/세로를 CGSize형으로 return
     }
     
@@ -175,4 +185,15 @@ extension TestChoiceViewController: UICollectionViewDelegateFlowLayout
         return 36
     }
     
+}
+
+extension TestChoiceViewController: AnswerCollectionViewCellDelegate {
+    func didSelectedAnswer(_ index: Int) {
+        guard let cell = answerCollectionView.visibleCells.first,
+              let currentNumber = answerCollectionView.indexPath(for: cell)?.item,
+              currentNumber < answerList.count else {
+            return
+        }
+        answers[currentNumber] = index
+    }
 }

--- a/DooRiBon/DooRiBon/Sources/Main/StyleTest/Views/AnswerView.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/StyleTest/Views/AnswerView.swift
@@ -1,0 +1,72 @@
+//
+//  AnswerView.swift
+//  DooRiBon
+//
+//  Created by Lee, Hyejin on 2021/07/13.
+//
+
+import UIKit
+import SnapKit
+
+protocol AnswerViewDelegate: NSObject {
+    func answerView(_ answerView: AnswerView, didSelected isSelected: Bool)
+}
+
+class AnswerView: UIView {
+    @IBOutlet weak var circleView: UIView!
+    @IBOutlet weak var numberLabel: UILabel!
+    @IBOutlet weak var answerLabel: UILabel!
+
+    weak var delegate: AnswerViewDelegate?
+
+    @IBInspectable
+    var number: Int {
+        get {
+            Int(numberLabel.text ?? "") ?? 0
+        }
+        set {
+            numberLabel.text = "\(newValue)"
+        }
+    }
+    var isSelected = false {
+        didSet {
+            updateSelection()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        let view = Bundle.main.loadNibNamed("AnswerView", owner: self, options: nil)?.first as! UIView
+        addSubview(view)
+        view.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        clipsToBounds = true
+
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(pressedAnswerView(_:)))
+        addGestureRecognizer(gesture)
+        isUserInteractionEnabled = true
+    }
+
+    private func updateSelection() {
+        backgroundColor = isSelected ? Colors.pointBlue.color : Colors.white9.color
+        circleView.backgroundColor = isSelected ? Colors.white9.color : Colors.subOrange1.color
+        numberLabel.textColor = isSelected ? Colors.pointBlue.color : Colors.white9.color
+        answerLabel.textColor = isSelected ? Colors.white9.color : Colors.black3.color
+    }
+
+    @objc private func pressedAnswerView(_ gesture: UITapGestureRecognizer) {
+        isSelected.toggle()
+        delegate?.answerView(self, didSelected: isSelected)
+    }
+}

--- a/DooRiBon/DooRiBon/Sources/Main/StyleTest/Views/AnswerView.xib
+++ b/DooRiBon/DooRiBon/Sources/Main/StyleTest/Views/AnswerView.xib
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="SpoqaHanSansNeo-Regular.ttf">
+            <string>SpoqaHanSansNeo-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AnswerView" customModule="DooRiBon" customModuleProvider="target">
+            <userDefinedRuntimeAttributes>
+                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                    <real key="value" value="8"/>
+                </userDefinedRuntimeAttribute>
+            </userDefinedRuntimeAttributes>
+            <connections>
+                <outlet property="answerLabel" destination="sW0-U3-Yhn" id="3pB-eP-weU"/>
+                <outlet property="circleView" destination="gF8-O8-Nzp" id="4xa-Tc-t9d"/>
+                <outlet property="numberLabel" destination="OZf-Tq-jNv" id="4Ge-Ko-Wde"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="9I6-9B-NqI">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="99"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gF8-O8-Nzp">
+                    <rect key="frame" x="10" y="37.5" width="24" height="24"/>
+                    <color key="backgroundColor" name="subOrange1"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="24" id="ClZ-wG-671"/>
+                        <constraint firstAttribute="width" secondItem="gF8-O8-Nzp" secondAttribute="height" multiplier="1:1" id="deo-ms-Z8n"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="12"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OZf-Tq-jNv">
+                    <rect key="frame" x="18" y="40.5" width="8" height="18"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="18" id="gr0-ds-UEX"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
+                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sW0-U3-Yhn">
+                    <rect key="frame" x="41" y="17" width="287" height="67"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="287" id="MZ3-ue-PAl"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="13"/>
+                    <color key="textColor" name="black3"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="zV1-2r-OwQ"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <gestureRecognizers/>
+            <constraints>
+                <constraint firstItem="sW0-U3-Yhn" firstAttribute="top" secondItem="9I6-9B-NqI" secondAttribute="top" constant="17" id="6um-Kx-Rxz"/>
+                <constraint firstAttribute="bottom" secondItem="sW0-U3-Yhn" secondAttribute="bottom" constant="15" id="BUg-Pm-f1B"/>
+                <constraint firstItem="gF8-O8-Nzp" firstAttribute="centerY" secondItem="9I6-9B-NqI" secondAttribute="centerY" id="QRV-Mb-TSk"/>
+                <constraint firstItem="OZf-Tq-jNv" firstAttribute="centerX" secondItem="gF8-O8-Nzp" secondAttribute="centerX" id="QbR-EH-meg"/>
+                <constraint firstItem="sW0-U3-Yhn" firstAttribute="leading" secondItem="gF8-O8-Nzp" secondAttribute="trailing" constant="7" id="eHJ-gA-WZN"/>
+                <constraint firstItem="OZf-Tq-jNv" firstAttribute="centerY" secondItem="gF8-O8-Nzp" secondAttribute="centerY" id="kbk-y0-VPm"/>
+                <constraint firstItem="gF8-O8-Nzp" firstAttribute="leading" secondItem="9I6-9B-NqI" secondAttribute="leading" constant="10" id="xwb-C5-BRA"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="513.04347826086962" y="-171.09375"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="black3">
+            <color red="0.27799999713897705" green="0.29800000786781311" blue="0.31799998879432678" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="subOrange1">
+            <color red="1" green="0.60000002384185791" blue="0.51800000667572021" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- BUG/#84

🌱 작업한 내용
- 여행 성향 화면 하나씩만 선택되도록 수정
#### TODO (cc. @mini-min)
- [ ] 답변을 선택했을 때만 다음 문항으로 넘어갈 수 있도록 하기
  - [ ] 다음 문항 버튼 enable 변경
  - [ ] 다음 문항 버튼 터치 불가할 때 색 변경
- [ ] answer 배열에 점수 더하도록 하기
- [ ] PopupView 공통 코드로 변경
- [ ] indicator 로직 변경

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF| <img src="https://user-images.githubusercontent.com/22652499/125453764-b6b9ff0f-a25b-4545-baf8-026af90a412f.gif" width=250\> |

## 📮 관련 이슈
- Resolved: #84 