### PR TITLE
[FEAT] #92 - 보드 조회 API 연결

### DIFF
--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
@@ -215,23 +215,9 @@ extension BoardViewController {
         let _ = iconTitleLabel.enumerated().map {
             $0.element.textColor = $0.0 == sender.tag ? Colors.pointOrange.color : Colors.gray5.color
         }
-        /// 각 버튼 클릭했을때 컨텐츠 영역 처리 (ex. 데이터 리로드)
-        switch sender.tag {
-        case 0:
-            selectedData = dummyData[0]
-            self.selectedTagIndex = 0
-        case 1:
-            selectedData = dummyData[1]
-            self.selectedTagIndex = 1
-        case 2:
-            selectedData = dummyData[2]
-            self.selectedTagIndex = 2
-        case 3:
-            selectedData = dummyData[3]
-            self.selectedTagIndex = 3
-        default:
-            return
-        }
+        
+        selectedData = dummyData[sender.tag]
+        selectedTagIndex = sender.tag
         
         guard let tag = Tag(rawValue: selectedTagIndex)?.description else { return }
         getBoardData(tag: tag)

--- a/DooRiBon/DooRiBon/Sources/Base/Board/Views/BoardPopupView.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/Views/BoardPopupView.swift
@@ -82,8 +82,6 @@ class BoardPopupView: UIView {
     }
     
     @IBAction func confirmButtonClicked(_ sender: Any) {
-//        print("confirm button click")
-//        print(self.contentsTextView.text)
         delegate?.sendContentsData(contents: self.contentsTextView.text)
         closeView(.confirm)
     }


### PR DESCRIPTION
## 🌴 PR 요약
보드 조회 API를 연결했습니다.

#### 다음과 같은 이슈가 존재합니다.
- 태그(버튼영역) 전환할때마다 서버 통신을 하느라 데이터 로드가 느린 문제
- 팝업에서 데이터를 추가하고 난 다음에 테이블뷰가 갱신되지 않는 이슈

🌱 작업한 브랜치
- feature/#92

🌱 작업한 내용
- getBoardData 서비스 코드 추가
- 가져온 데이터 테이블뷰에 로드

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![Simulator Screen Recording - iPhone 11 Pro - 2021-07-14 at 05 40 34](https://user-images.githubusercontent.com/61109660/125521754-10445c68-2a7e-41dc-b52f-1618dc008fcd.gif)|

## 📮 관련 이슈
- Resolved: #92