### PR TITLE
[FEAT] #97 - 메인에서 탭바 컨트롤러로 화면 전환 시 데이터 전달

### DIFF
--- a/DooRiBon/DooRiBon/Application/SceneDelegate.swift
+++ b/DooRiBon/DooRiBon/Application/SceneDelegate.swift
@@ -19,8 +19,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         
         // 맨 처음 보여줄 뷰 컨트롤러 객체 생성 (루트 뷰 컨트롤러로 사용할 객체)
-        let rootViewController = UIStoryboard(name: "TestChoiceStoryboard", bundle: nil)
-            .instantiateViewController(identifier: "TestChoiceViewController")
+        let rootViewController = UIStoryboard(name: "MainStoryboard", bundle: nil)
+            .instantiateViewController(identifier: "MainViewController")
 
         
         // 윈도우 위에 쌓이는 것 중에서 윈도우와 가장 근접한 부분을 rootViewController 라고 함

--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardStoryboard.storyboard
@@ -228,7 +228,7 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="tableView" destination="YCS-k1-Rpy" id="XdP-c9-1GN"/>
-                        <outlet property="topContainerView" destination="gyK-uK-iJ4" id="SoY-Kf-oTw"/>
+                        <outlet property="topView" destination="gyK-uK-iJ4" id="iRZ-b2-dhh"/>
                         <outletCollection property="iconImageView" destination="5oc-D0-hsE" collectionClass="NSMutableArray" id="CmF-zv-47g"/>
                         <outletCollection property="iconImageView" destination="xpx-0U-fxz" collectionClass="NSMutableArray" id="uu6-18-dqX"/>
                         <outletCollection property="iconImageView" destination="hK4-af-mC4" collectionClass="NSMutableArray" id="o95-cI-1be"/>

--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
@@ -38,7 +38,6 @@ class BoardViewController: UIViewController {
     @IBOutlet weak private var tableView: UITableView!
     
     // MARK: - Properties
-//    let topView = TripTopView()
     let iconName = ["Goal", "Aim", "Role", "Check"]
     let dummyData = [
         DummyDataModel(titleName: "우리의 여행 목표",
@@ -170,7 +169,7 @@ extension BoardViewController {
     }
     
     @objc func backButtonClicked(_ sender: UIButton) {
-        navigationController?.popViewController(animated: true)
+        dismiss(animated: true, completion: nil)
     }
     
     @objc func profileButtonClicked(_ sender: UIButton) {
@@ -297,7 +296,6 @@ extension BoardViewController: UITableViewDataSource {
             cell.setData(goalContents: data.content, userName: data.name)
         }
         
-
         return cell
     }
 }

--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
@@ -32,14 +32,13 @@ enum Tag: Int {
 class BoardViewController: UIViewController {
     // MARK: - IBOutlets
     
-    @IBOutlet weak var topContainerView: TripTopView!
+    @IBOutlet weak var topView: TripTopView!
     @IBOutlet var iconImageView: [UIImageView]!
     @IBOutlet var iconTitleLabel: [UILabel]!
     @IBOutlet weak private var tableView: UITableView!
     
     // MARK: - Properties
-    
-    let topView = TripTopView()
+//    let topView = TripTopView()
     let iconName = ["Goal", "Aim", "Role", "Check"]
     let dummyData = [
         DummyDataModel(titleName: "우리의 여행 목표",
@@ -93,7 +92,7 @@ class BoardViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        setupTopView()
         guard let tag = Tag(rawValue: selectedTagIndex)?.description else { return }
         getBoardData(tag: tag)
     }
@@ -144,6 +143,11 @@ class BoardViewController: UIViewController {
 
 extension BoardViewController {
     // MARK: - Setup
+    /// TopView Setup
+    private func setupTopView() {
+        guard let model = (self.tabBarController as! TripViewController).tripData else { return }
+        topView.setTopViewData(tripData: model)
+    }
     
     private func setupUI() {
         navigationController?.navigationBar.isHidden = true
@@ -158,11 +162,11 @@ extension BoardViewController {
     // MARK: - Button Actions
     
     private func setupButtonAction() {
-        topContainerView.backButton.addTarget(self, action: #selector(backButtonClicked), for: .touchUpInside)
-        topContainerView.profileButton.addTarget(self, action: #selector(profileButtonClicked), for: .touchUpInside)
-        topContainerView.settingButton.addTarget(self, action: #selector(settingButtonClicked), for: .touchUpInside)
-        topContainerView.memberButton.addTarget(self, action: #selector(memberButtonClicked), for: .touchUpInside)
-        topContainerView.codeButton.addTarget(self, action: #selector(codeButtonClicked), for: .touchUpInside)
+        topView.backButton.addTarget(self, action: #selector(backButtonClicked), for: .touchUpInside)
+        topView.profileButton.addTarget(self, action: #selector(profileButtonClicked), for: .touchUpInside)
+        topView.settingButton.addTarget(self, action: #selector(settingButtonClicked), for: .touchUpInside)
+        topView.memberButton.addTarget(self, action: #selector(memberButtonClicked), for: .touchUpInside)
+        topView.codeButton.addTarget(self, action: #selector(codeButtonClicked), for: .touchUpInside)
     }
     
     @objc func backButtonClicked(_ sender: UIButton) {

--- a/DooRiBon/DooRiBon/Sources/Base/Member/MemberViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Member/MemberViewController.swift
@@ -31,9 +31,20 @@ class MemberViewController: UIViewController {
         // 상단영역 버튼 액션 연결
         setupButtonAction()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupTopView()
+    }
 }
 
 extension MemberViewController {
+    /// TopView Setup
+    private func setupTopView() {
+        guard let model = (self.tabBarController as! TripViewController).tripData else { return }
+        topView.setTopViewData(tripData: model)
+    }
+    
     // MARK: - Button Actions
     
     private func setupButtonAction() {

--- a/DooRiBon/DooRiBon/Sources/Base/Member/MemberViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Member/MemberViewController.swift
@@ -56,7 +56,7 @@ extension MemberViewController {
     }
     
     @objc func backButtonClicked(_ sender: UIButton) {
-        navigationController?.popViewController(animated: true)
+        dismiss(animated: true, completion: nil)
     }
     
     @objc func profileButtonClicked(_ sender: UIButton) {

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
@@ -46,7 +46,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="79" height="71"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rit-r2-uHf">
-                                                <rect key="frame" x="34" y="13" width="19.5" height="10.5"/>
+                                                <rect key="frame" x="34" y="13" width="18" height="9.5"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="8"/>
                                                 <color key="textColor" name="subBlue1"/>
                                                 <nil key="highlightedColor"/>

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanStoryboard.storyboard
@@ -46,7 +46,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="79" height="71"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rit-r2-uHf">
-                                                <rect key="frame" x="34" y="13" width="18" height="9.5"/>
+                                                <rect key="frame" x="34" y="13" width="19.5" height="10.5"/>
                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="8"/>
                                                 <color key="textColor" name="subBlue1"/>
                                                 <nil key="highlightedColor"/>

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
@@ -53,6 +53,11 @@ class PlanViewController: UIViewController {
         setupData()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupTopView()
+    }
+    
     // MARK: - IBActions
 }
 
@@ -99,6 +104,12 @@ extension PlanViewController {
     
     @objc func codeButtonClicked(_ sender: UIButton) {
         ToastView.show("참여코드 복사 완료! 원하는 곳에 붙여넣기 하세요.")
+    }
+    
+    /// TopView Setup
+    private func setupTopView() {
+        guard let model = (self.tabBarController as! TripViewController).tripData else { return }
+        topView.setTopViewData(tripData: model)
     }
     
     /// CollectionView Setup

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
@@ -87,7 +87,7 @@ extension PlanViewController {
     }
     
     @objc func backButtonClicked(_ sender: UIButton) {
-        navigationController?.popViewController(animated: true)
+        dismiss(animated: true, completion: nil)
     }
     
     @objc func profileButtonClicked(_ sender: UIButton) {

--- a/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
@@ -43,8 +43,6 @@ class TripViewController: UITabBarController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        print(tripData!)
     }
     
 

--- a/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
@@ -27,6 +27,11 @@ class TripViewController: UITabBarController {
     // MARK: - Properties
     
     let appearance = UITabBarItem.appearance()
+    var tripData: Group? {
+        didSet {
+            print("tripData")
+        }
+    }
 
     // MARK: - Life Cycles
     
@@ -34,6 +39,12 @@ class TripViewController: UITabBarController {
         super.viewDidLoad()
         
         configureUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        print(tripData!)
     }
     
 

--- a/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/TripViewController.swift
@@ -27,11 +27,7 @@ class TripViewController: UITabBarController {
     // MARK: - Properties
     
     let appearance = UITabBarItem.appearance()
-    var tripData: Group? {
-        didSet {
-            print("tripData")
-        }
-    }
+    var tripData: Group?
 
     // MARK: - Life Cycles
     

--- a/DooRiBon/DooRiBon/Sources/Common/TripTop/TripTopView.swift
+++ b/DooRiBon/DooRiBon/Sources/Common/TripTop/TripTopView.swift
@@ -9,6 +9,10 @@ import UIKit
 
 class TripTopView: UIView {
     // MARK: - IBOutlets
+    @IBOutlet weak var periodLabel: UILabel!
+    @IBOutlet weak var tripTitleLabel: UILabel!
+    @IBOutlet weak var destinationLabel: UILabel!
+    @IBOutlet weak var memberDescriptionLabel: UILabel!
     
     @IBOutlet weak var backButton: UIButton!
     @IBOutlet weak var profileButton: UIButton!
@@ -17,6 +21,10 @@ class TripTopView: UIView {
     @IBOutlet weak var codeButton: UIButton!
     
     let xibName = "TripTopView"
+    let formatter = DateFormatter()
+    let calendar = Calendar.current
+    private var startDate: Date?
+    private var endDate: Date?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -32,5 +40,20 @@ class TripTopView: UIView {
         let view = Bundle.main.loadNibNamed(xibName, owner: self, options: nil)?.first as! UIView
         view.frame = self.bounds
         self.addSubview(view)
+    }
+    
+    func setTopViewData(tripData: Group) {
+        startDate = tripData.startDate
+        endDate = tripData.endDate
+    
+        formatter.dateFormat = "yyyy.MM.dd"
+        let start = formatter.string(from: tripData.startDate)
+        formatter.dateFormat = "MM.dd"
+        let end = formatter.string(from: tripData.endDate)
+        
+        periodLabel.text = "\(start) - \(end)"
+        tripTitleLabel.text = tripData.travelName
+        destinationLabel.text = tripData.destination
+        memberDescriptionLabel.text = tripData.members[0]
     }
 }

--- a/DooRiBon/DooRiBon/Sources/Common/TripTop/TripTopView.xib
+++ b/DooRiBon/DooRiBon/Sources/Common/TripTop/TripTopView.xib
@@ -21,9 +21,13 @@
             <connections>
                 <outlet property="backButton" destination="Nlm-59-Pcf" id="rzB-i7-fcu"/>
                 <outlet property="codeButton" destination="pHB-75-SWd" id="Pd4-J3-KjB"/>
+                <outlet property="destinationLabel" destination="iu7-21-mTy" id="8I2-OL-TBK"/>
                 <outlet property="memberButton" destination="gku-5F-UaV" id="xoY-CU-UzM"/>
+                <outlet property="memberDescriptionLabel" destination="ljy-zR-Dlw" id="VjA-hG-5bG"/>
+                <outlet property="periodLabel" destination="xaF-LN-CXU" id="9dS-iY-NXr"/>
                 <outlet property="profileButton" destination="Sra-ab-z3R" id="Maj-lC-wio"/>
                 <outlet property="settingButton" destination="x9s-Ck-9rc" id="Mgb-z5-URl"/>
+                <outlet property="tripTitleLabel" destination="zQX-er-1MN" id="OB1-7D-xfi"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -32,19 +36,19 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021. 07. 29 - 08. 02" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xaF-LN-CXU">
-                    <rect key="frame" x="18" y="86" width="339" height="18.666666666666671"/>
+                    <rect key="frame" x="18" y="86" width="339" height="20.333333333333329"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="16"/>
                     <color key="textColor" name="pointBlue"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="떠나요 두리번 to 제주" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zQX-er-1MN">
-                    <rect key="frame" x="18" y="108.66666666666667" width="199" height="27.000000000000014"/>
+                    <rect key="frame" x="18" y="110.33333333333333" width="209.33333333333334" height="28.999999999999986"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="23"/>
                     <color key="textColor" name="black1"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x9s-Ck-9rc">
-                    <rect key="frame" x="224" y="112.66666666666667" width="20" height="20.000000000000014"/>
+                    <rect key="frame" x="234.33333333333334" y="114.33333333333333" width="20" height="19.999999999999986"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="OYe-c9-5Wn"/>
                         <constraint firstAttribute="width" constant="20" id="sPb-tN-Br5"/>
@@ -52,7 +56,7 @@
                     <state key="normal" image="iconSettings"/>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Klq-6B-6i3">
-                    <rect key="frame" x="18" y="143.66666666666666" width="109" height="28"/>
+                    <rect key="frame" x="18" y="147.33333333333334" width="109" height="28"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconAirplaneFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yln-Ru-tmy">
                             <rect key="frame" x="8" y="4" width="20" height="20"/>
@@ -62,7 +66,7 @@
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제주도 제주시" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iu7-21-mTy">
-                            <rect key="frame" x="29" y="7" width="72" height="14"/>
+                            <rect key="frame" x="29" y="6.3333333333333153" width="72" height="15.333333333333336"/>
                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                             <color key="textColor" name="gray4"/>
                             <nil key="highlightedColor"/>
@@ -85,7 +89,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hhG-uV-akM">
-                    <rect key="frame" x="134" y="143.66666666666666" width="161" height="28"/>
+                    <rect key="frame" x="134" y="147.33333333333334" width="161" height="28"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUserMainMid" translatesAutoresizingMaskIntoConstraints="NO" id="PCm-C2-kyb">
                             <rect key="frame" x="8" y="5" width="18" height="18"/>
@@ -95,7 +99,7 @@
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="김민영님 외 4명과 함께" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ljy-zR-Dlw">
-                            <rect key="frame" x="30" y="7" width="123" height="14"/>
+                            <rect key="frame" x="30" y="6.3333333333333153" width="123" height="15.333333333333336"/>
                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                             <color key="textColor" name="gray4"/>
                             <nil key="highlightedColor"/>
@@ -118,7 +122,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pHB-75-SWd" userLabel="plusButton">
-                    <rect key="frame" x="281" y="140.33333333333334" width="35" height="35"/>
+                    <rect key="frame" x="281" y="144" width="35" height="35"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="35" id="VTF-zI-vEr"/>
                         <constraint firstAttribute="width" constant="35" id="gfn-8D-Wz5"/>
@@ -126,7 +130,7 @@
                     <state key="normal" image="btnAddpeopleCopycode"/>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gku-5F-UaV">
-                    <rect key="frame" x="134" y="143.66666666666666" width="147" height="28"/>
+                    <rect key="frame" x="134" y="147.33333333333334" width="147" height="28"/>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sra-ab-z3R">
                     <rect key="frame" x="336" y="46" width="24" height="24"/>

--- a/DooRiBon/DooRiBon/Sources/Main/MainStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Main/MainStoryboard.storyboard
@@ -87,6 +87,9 @@
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="323" id="vhc-Vu-qa4"/>
                                                         </constraints>
+                                                        <connections>
+                                                            <action selector="nowTripClicked:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="EhC-ZO-jb8"/>
+                                                        </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020.05.21 - 2020.05.27" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O1A-tm-fec">
                                                         <rect key="frame" x="19" y="298" width="201" height="25"/>

--- a/DooRiBon/DooRiBon/Sources/Main/MainStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Main/MainStoryboard.storyboard
@@ -68,9 +68,8 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Su3-7g-8tG">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="405"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HB0-bl-kBm">
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="HB0-bl-kBm">
                                                         <rect key="frame" x="0.0" y="82" width="375" height="323"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                                                 <real key="value" value="30"/>
@@ -108,7 +107,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zrM-CO-Jmd">
-                                                        <rect key="frame" x="18" y="363" width="95" height="24"/>
+                                                        <rect key="frame" x="17.999999999999993" y="363" width="92.333333333333314" height="24"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconAirplaneFill" translatesAutoresizingMaskIntoConstraints="NO" id="uCC-0G-kXq">
                                                                 <rect key="frame" x="8" y="2" width="20" height="20"/>
@@ -118,7 +117,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="강원도 속초" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1fg-2T-xcS">
-                                                                <rect key="frame" x="29" y="3" width="58" height="18"/>
+                                                                <rect key="frame" x="29.000000000000004" y="3" width="55.333333333333343" height="18"/>
                                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                                                 <color key="textColor" name="white9"/>
                                                                 <nil key="highlightedColor"/>
@@ -143,7 +142,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OPJ-yc-IZw">
-                                                        <rect key="frame" x="121" y="363" width="100" height="24"/>
+                                                        <rect key="frame" x="118.33333333333331" y="363" width="100" height="24"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUserMainTop" translatesAutoresizingMaskIntoConstraints="NO" id="oY9-5q-u4r">
                                                                 <rect key="frame" x="8" y="3" width="18" height="18"/>
@@ -153,7 +152,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00님과 함께" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cd6-x1-dsy">
-                                                                <rect key="frame" x="29" y="3" width="63" height="18"/>
+                                                                <rect key="frame" x="29.000000000000014" y="3" width="63" height="18"/>
                                                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                                                 <color key="textColor" name="white9"/>
                                                                 <nil key="highlightedColor"/>
@@ -217,6 +216,7 @@
                                                     <constraint firstItem="l0p-Dw-FG6" firstAttribute="leading" secondItem="Su3-7g-8tG" secondAttribute="leading" id="FnJ-Hb-Bdz"/>
                                                     <constraint firstItem="tZI-OE-Apb" firstAttribute="top" secondItem="O1A-tm-fec" secondAttribute="bottom" id="IWe-WR-qJe"/>
                                                     <constraint firstAttribute="trailing" secondItem="l0p-Dw-FG6" secondAttribute="trailing" id="KbH-3Q-UAw"/>
+                                                    <constraint firstItem="HB0-bl-kBm" firstAttribute="leading" secondItem="Su3-7g-8tG" secondAttribute="leading" id="Kq8-es-9cb"/>
                                                     <constraint firstItem="OPJ-yc-IZw" firstAttribute="centerY" secondItem="zrM-CO-Jmd" secondAttribute="centerY" id="Ori-gb-yCs"/>
                                                     <constraint firstAttribute="height" constant="405" id="Pxr-65-nND"/>
                                                     <constraint firstAttribute="bottom" secondItem="zrM-CO-Jmd" secondAttribute="bottom" constant="18" id="Rnh-AC-xBH"/>
@@ -225,9 +225,12 @@
                                                     <constraint firstItem="qO8-47-OZQ" firstAttribute="leading" secondItem="Su3-7g-8tG" secondAttribute="leading" constant="20" id="VR8-IS-lf5"/>
                                                     <constraint firstAttribute="trailing" secondItem="tZI-OE-Apb" secondAttribute="trailing" constant="110" id="c6r-qv-n1K"/>
                                                     <constraint firstItem="zrM-CO-Jmd" firstAttribute="leading" secondItem="Su3-7g-8tG" secondAttribute="leading" constant="18" id="gNY-LA-Hco"/>
+                                                    <constraint firstAttribute="bottom" secondItem="HB0-bl-kBm" secondAttribute="bottom" id="kCu-7U-bMJ"/>
+                                                    <constraint firstItem="HB0-bl-kBm" firstAttribute="top" secondItem="qO8-47-OZQ" secondAttribute="bottom" constant="12" id="sd6-7s-MmA"/>
                                                     <constraint firstAttribute="bottom" secondItem="l0p-Dw-FG6" secondAttribute="bottom" id="stq-dR-L9y"/>
                                                     <constraint firstAttribute="trailing" secondItem="O1A-tm-fec" secondAttribute="trailing" constant="155" id="v7O-Qd-WeF"/>
                                                     <constraint firstItem="qO8-47-OZQ" firstAttribute="top" secondItem="Su3-7g-8tG" secondAttribute="top" constant="4" id="vOi-sr-8a1"/>
+                                                    <constraint firstAttribute="trailing" secondItem="HB0-bl-kBm" secondAttribute="trailing" id="yEU-ut-9FY"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ru8-V5-fnM">
@@ -284,7 +287,6 @@
                                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lOX-XR-s64">
                                                                             <rect key="frame" x="0.0" y="0.0" width="135" height="140"/>
                                                                             <constraints>
-                                                                                <constraint firstAttribute="height" constant="140" id="riD-5N-PDV"/>
                                                                                 <constraint firstAttribute="width" constant="135" id="wRx-P6-LcA"/>
                                                                             </constraints>
                                                                         </imageView>
@@ -316,7 +318,7 @@
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sja-dv-ExH">
-                                                                            <rect key="frame" x="149" y="75" width="95" height="24"/>
+                                                                            <rect key="frame" x="149" y="75" width="92.333333333333314" height="24"/>
                                                                             <subviews>
                                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconAirplaneFill" translatesAutoresizingMaskIntoConstraints="NO" id="81R-bK-vnp">
                                                                                     <rect key="frame" x="8" y="2" width="20" height="20"/>
@@ -326,7 +328,7 @@
                                                                                     </constraints>
                                                                                 </imageView>
                                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="강원도 속초" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pwY-Qg-rCU">
-                                                                                    <rect key="frame" x="29" y="3" width="58" height="18"/>
+                                                                                    <rect key="frame" x="29.000000000000004" y="3" width="55.333333333333343" height="18"/>
                                                                                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                                                                     <color key="textColor" name="gray4"/>
                                                                                     <nil key="highlightedColor"/>
@@ -357,7 +359,7 @@
                                                                             </userDefinedRuntimeAttributes>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Ts-Dp-lKq">
-                                                                            <rect key="frame" x="149" y="104" width="140.66666666666663" height="24"/>
+                                                                            <rect key="frame" x="149" y="104" width="137" height="24"/>
                                                                             <subviews>
                                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUserMainMid" translatesAutoresizingMaskIntoConstraints="NO" id="rZD-8z-ObU">
                                                                                     <rect key="frame" x="8" y="3" width="18" height="18"/>
@@ -367,7 +369,7 @@
                                                                                     </constraints>
                                                                                 </imageView>
                                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미몽님 외 3명과 함께" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Abe-TP-KkW">
-                                                                                    <rect key="frame" x="29.000000000000007" y="3" width="103.66666666666669" height="18"/>
+                                                                                    <rect key="frame" x="29" y="3" width="100" height="18"/>
                                                                                     <constraints>
                                                                                         <constraint firstAttribute="width" constant="104" id="aga-77-hpe"/>
                                                                                     </constraints>
@@ -410,6 +412,7 @@
                                                                     <constraints>
                                                                         <constraint firstItem="aLi-JL-Q3T" firstAttribute="leading" secondItem="lOX-XR-s64" secondAttribute="trailing" constant="17" id="0Cc-9F-lfg"/>
                                                                         <constraint firstItem="eNT-ZD-7T8" firstAttribute="leading" secondItem="lOX-XR-s64" secondAttribute="trailing" constant="16" id="4vI-FQ-ugJ"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="lOX-XR-s64" secondAttribute="bottom" id="91R-sx-tsd"/>
                                                                         <constraint firstAttribute="trailing" secondItem="eUZ-6T-qNN" secondAttribute="trailing" constant="130" id="JR7-bg-jMD"/>
                                                                         <constraint firstItem="sja-dv-ExH" firstAttribute="leading" secondItem="lOX-XR-s64" secondAttribute="trailing" constant="14" id="May-3y-fjp"/>
                                                                         <constraint firstItem="eUZ-6T-qNN" firstAttribute="top" secondItem="a74-bP-cah" secondAttribute="top" constant="9" id="Phe-Io-vPP"/>
@@ -503,7 +506,7 @@
                                                 <rect key="frame" x="0.0" y="696" width="375" height="471"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="추억 속 지난 여행" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e4P-fF-cjq">
-                                                        <rect key="frame" x="20" y="31" width="128.33333333333334" height="22.666666666666671"/>
+                                                        <rect key="frame" x="19.999999999999993" y="31" width="124.33333333333331" height="21"/>
                                                         <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="18"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -553,7 +556,7 @@
                                                                             <state key="normal" image="iconRightStroke"/>
                                                                         </button>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sTA-4j-VJN">
-                                                                            <rect key="frame" x="167" y="61" width="95" height="24"/>
+                                                                            <rect key="frame" x="167" y="61" width="92.333333333333314" height="24"/>
                                                                             <subviews>
                                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconAirplaneFill" translatesAutoresizingMaskIntoConstraints="NO" id="nJV-kq-2Bn">
                                                                                     <rect key="frame" x="8" y="2" width="20" height="20"/>
@@ -563,7 +566,7 @@
                                                                                     </constraints>
                                                                                 </imageView>
                                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="강원도 속초" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sKu-Fa-RHr">
-                                                                                    <rect key="frame" x="29" y="3" width="58" height="18"/>
+                                                                                    <rect key="frame" x="29.000000000000004" y="3" width="55.333333333333343" height="18"/>
                                                                                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                                                                     <color key="textColor" name="gray4"/>
                                                                                     <nil key="highlightedColor"/>
@@ -594,7 +597,7 @@
                                                                             </userDefinedRuntimeAttributes>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="37w-6D-o7i">
-                                                                            <rect key="frame" x="167" y="91" width="141" height="24"/>
+                                                                            <rect key="frame" x="167" y="91" width="137" height="24"/>
                                                                             <subviews>
                                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUserMainMid" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-ki-ndz">
                                                                                     <rect key="frame" x="8" y="3" width="18" height="18"/>
@@ -604,7 +607,7 @@
                                                                                     </constraints>
                                                                                 </imageView>
                                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미몽님 외 3명과 함께" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v8I-Tc-NWg">
-                                                                                    <rect key="frame" x="29" y="3" width="104" height="18"/>
+                                                                                    <rect key="frame" x="29" y="3" width="100" height="18"/>
                                                                                     <constraints>
                                                                                         <constraint firstAttribute="width" constant="104" id="bIv-D4-vSm"/>
                                                                                     </constraints>
@@ -706,7 +709,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="작은 움직임이 만드는 우리다운 여행" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PUU-Xc-iU6">
-                                                        <rect key="frame" x="71" y="78" width="233" height="15.333333333333329"/>
+                                                        <rect key="frame" x="71" y="78" width="233" height="14"/>
                                                         <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                                         <color key="textColor" name="gray6"/>
                                                         <nil key="highlightedColor"/>
@@ -726,13 +729,13 @@
                                                 <rect key="frame" x="0.0" y="1167" width="375" height="523"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미몽님은 어떤 여행을 좋아하세요?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DnP-lS-p1V">
-                                                        <rect key="frame" x="18" y="40" width="274" height="45.333333333333343"/>
+                                                        <rect key="frame" x="18" y="40" width="274" height="42"/>
                                                         <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="18"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C35-t1-y67">
-                                                        <rect key="frame" x="20" y="115.33333333333326" width="338" height="408"/>
+                                                        <rect key="frame" x="20" y="112" width="338" height="408"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imageDum" translatesAutoresizingMaskIntoConstraints="NO" id="kqc-Lw-BtJ">
                                                                 <rect key="frame" x="13" y="16" width="312" height="237"/>
@@ -836,7 +839,7 @@
                             <constraint firstItem="JYu-94-62j" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" priority="250" id="9wQ-Mk-hKl"/>
                             <constraint firstItem="R6p-in-uld" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="FFC-pO-z8y"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="R6p-in-uld" secondAttribute="trailing" id="Jxa-ZY-Llj"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="9b9-AS-Jj4" secondAttribute="trailing" id="VJB-I3-yoP"/>
+                            <constraint firstAttribute="trailing" secondItem="9b9-AS-Jj4" secondAttribute="trailing" id="VJB-I3-yoP"/>
                             <constraint firstItem="9b9-AS-Jj4" firstAttribute="top" secondItem="R6p-in-uld" secondAttribute="bottom" id="Vaw-7y-jjp"/>
                             <constraint firstAttribute="bottom" secondItem="9b9-AS-Jj4" secondAttribute="bottom" id="XDG-6n-g1e"/>
                             <constraint firstItem="R6p-in-uld" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="e4g-cu-4ps"/>

--- a/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
@@ -67,8 +67,6 @@ class MainViewController: UIViewController {
     // MARK: - 액션
     
     @IBAction func nowTripClicked(_ sender: Any) {
-//        print(11111, nowTripList[0])
-        
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
             navigationController?.pushViewController(tripVC, animated: true)
@@ -234,8 +232,6 @@ extension MainViewController: UICollectionViewDataSource
 extension MainViewController: UICollectionViewDelegate
 {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-//        print(333333, comeTripList[indexPath.row])
-        
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
             navigationController?.pushViewController(tripVC, animated: true)
@@ -276,8 +272,6 @@ extension MainViewController: UICollectionViewDelegateFlowLayout
 extension MainViewController: UITableViewDataSource, UITableViewDelegate
 {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        print(333333, lastTripList[indexPath.row])
-        
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
             navigationController?.pushViewController(tripVC, animated: true)

--- a/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
@@ -69,8 +69,9 @@ class MainViewController: UIViewController {
     @IBAction func nowTripClicked(_ sender: Any) {
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
-            navigationController?.pushViewController(tripVC, animated: true)
+            tripVC.modalPresentationStyle = .overFullScreen
             tripVC.tripData = nowTripList[0]
+            present(tripVC, animated: true, completion: nil)
         }
         print(nowTripList)
     }
@@ -236,8 +237,9 @@ extension MainViewController: UICollectionViewDelegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
-            navigationController?.pushViewController(tripVC, animated: true)
+            tripVC.modalPresentationStyle = .overFullScreen
             tripVC.tripData = comeTripList[indexPath.row]
+            present(tripVC, animated: true, completion: nil)
         }
     }
 }
@@ -276,8 +278,9 @@ extension MainViewController: UITableViewDataSource, UITableViewDelegate
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
-            navigationController?.pushViewController(tripVC, animated: true)
+            tripVC.modalPresentationStyle = .overFullScreen
             tripVC.tripData = lastTripList[indexPath.row]
+            present(tripVC, animated: true, completion: nil)
         }
     }
     

--- a/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
@@ -72,6 +72,7 @@ class MainViewController: UIViewController {
             navigationController?.pushViewController(tripVC, animated: true)
             tripVC.tripData = nowTripList[0]
         }
+        print(nowTripList)
     }
     
     // 새로운 여행 시작하기 : 팝업 StartTrip 뷰컨으로 이동 -> 팝업과 뒷 화면을 연결해야함
@@ -147,6 +148,7 @@ class MainViewController: UIViewController {
         let start = formatter.string(from: nowTripList[0].startDate)
         let end = formatter.string(from: nowTripList[0].endDate)
         nowTripDateLabel.text = "\(start) - \(end)"
+        self.nowTripTitleLabel.text = nowTripList[0].travelName
         self.nowTripLocationLabel.text = nowTripList[0].destination
         if nowTripList[0].members.count == 1 {
             nowTripMembersLabel.text = "\(nowTripList[0].members[0])님과 함께"

--- a/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
@@ -53,7 +53,6 @@ class MainViewController: UIViewController {
 
         setUI()
         shadowSet()
-
     }
     
     // MARK: - viewWillAppear
@@ -63,15 +62,17 @@ class MainViewController: UIViewController {
         setTripData()
         collectionViewSet()
         tableViewSet()
-
     }
     
     // MARK: - 액션
     
     @IBAction func nowTripClicked(_ sender: Any) {
+//        print(11111, nowTripList[0])
+        
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
             navigationController?.pushViewController(tripVC, animated: true)
+            tripVC.tripData = nowTripList[0]
         }
     }
     
@@ -233,9 +234,12 @@ extension MainViewController: UICollectionViewDataSource
 extension MainViewController: UICollectionViewDelegate
 {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+//        print(333333, comeTripList[indexPath.row])
+        
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
             navigationController?.pushViewController(tripVC, animated: true)
+            tripVC.tripData = comeTripList[indexPath.row]
         }
     }
 }
@@ -272,9 +276,12 @@ extension MainViewController: UICollectionViewDelegateFlowLayout
 extension MainViewController: UITableViewDataSource, UITableViewDelegate
 {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        print(333333, lastTripList[indexPath.row])
+        
         let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
         if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
             navigationController?.pushViewController(tripVC, animated: true)
+            tripVC.tripData = lastTripList[indexPath.row]
         }
     }
     

--- a/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
@@ -68,6 +68,13 @@ class MainViewController: UIViewController {
     
     // MARK: - 액션
     
+    @IBAction func nowTripClicked(_ sender: Any) {
+        let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
+        if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
+            navigationController?.pushViewController(tripVC, animated: true)
+        }
+    }
+    
     // 새로운 여행 시작하기 : 팝업 StartTrip 뷰컨으로 이동 -> 팝업과 뒷 화면을 연결해야함
     @IBAction func StartTripButtonClicked(_ sender: Any) {
         let nextVC = StartTripViewController(nibName: "StartTripViewController", bundle: nil)
@@ -264,6 +271,13 @@ extension MainViewController: UICollectionViewDelegateFlowLayout
 
 extension MainViewController: UITableViewDataSource, UITableViewDelegate
 {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let tripStortboard = UIStoryboard(name: "TripStoryboard", bundle: nil)
+        if let tripVC = tripStortboard.instantiateViewController(identifier: "TripViewController") as? TripViewController {
+            navigationController?.pushViewController(tripVC, animated: true)
+        }
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return lastTripList.count
     }

--- a/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/MainViewController.swift
@@ -291,7 +291,6 @@ extension MainViewController: UITableViewDataSource, UITableViewDelegate
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         guard let tripCell = tableView.dequeueReusableCell(withIdentifier: LastTripTableViewCell.identifier, for: indexPath) as? LastTripTableViewCell else {return UITableViewCell() }
-        print("test")
         tripCell.setdata(imageName: lastTripList[indexPath.row].image,
                          title: lastTripList[indexPath.row].travelName,
                          location: lastTripList[indexPath.row].destination,

--- a/DooRiBon/Podfile
+++ b/DooRiBon/Podfile
@@ -11,4 +11,6 @@ target 'DooRiBon' do
   pod 'FSCalendar', :git => 'https://github.com/hyejinL/FSCalendar.git', :branch => 'dooribun'
    # Pods for FSCalendarPractice
   pod 'Kingfisher', '~> 6.0'
+  pod 'MaterialComponents/BottomSheet'
+  pod 'MaterialComponents/BottomSheet+ShapeThemer'
 end

--- a/DooRiBon/Podfile.lock
+++ b/DooRiBon/Podfile.lock
@@ -2,18 +2,56 @@ PODS:
   - Alamofire (5.4.1)
   - FSCalendar (2.8.3)
   - Kingfisher (6.1.0)
+  - MaterialComponents/Availability (124.2.0)
+  - MaterialComponents/BottomSheet (124.2.0):
+    - MaterialComponents/Elevation
+    - MaterialComponents/private/KeyboardWatcher
+    - MaterialComponents/private/Math
+    - MaterialComponents/ShadowElevations
+    - MaterialComponents/ShadowLayer
+    - MaterialComponents/ShapeLibrary
+    - MaterialComponents/Shapes
+  - "MaterialComponents/BottomSheet+ShapeThemer (124.2.0)":
+    - MaterialComponents/BottomSheet
+    - MaterialComponents/schemes/Shape
+  - MaterialComponents/Elevation (124.2.0):
+    - MaterialComponents/Availability
+    - MaterialComponents/private/Color
+    - MaterialComponents/private/Math
+  - MaterialComponents/private/Application (124.2.0)
+  - MaterialComponents/private/Color (124.2.0):
+    - MaterialComponents/Availability
+  - MaterialComponents/private/KeyboardWatcher (124.2.0):
+    - MaterialComponents/private/Application
+  - MaterialComponents/private/Math (124.2.0)
+  - MaterialComponents/schemes/Shape (124.2.0):
+    - MaterialComponents/ShapeLibrary
+    - MaterialComponents/Shapes
+  - MaterialComponents/ShadowElevations (124.2.0)
+  - MaterialComponents/ShadowLayer (124.2.0):
+    - MaterialComponents/ShadowElevations
+  - MaterialComponents/ShapeLibrary (124.2.0):
+    - MaterialComponents/private/Math
+    - MaterialComponents/Shapes
+  - MaterialComponents/Shapes (124.2.0):
+    - MaterialComponents/private/Color
+    - MaterialComponents/private/Math
+    - MaterialComponents/ShadowLayer
   - SnapKit (5.0.1)
 
 DEPENDENCIES:
   - Alamofire (~> 5.4)
   - FSCalendar (from `https://github.com/hyejinL/FSCalendar.git`, branch `dooribun`)
   - Kingfisher (~> 6.0)
+  - MaterialComponents/BottomSheet
+  - "MaterialComponents/BottomSheet+ShapeThemer"
   - SnapKit (~> 5.0.0)
 
 SPEC REPOS:
   trunk:
     - Alamofire
     - Kingfisher
+    - MaterialComponents
     - SnapKit
 
 EXTERNAL SOURCES:
@@ -30,8 +68,9 @@ SPEC CHECKSUMS:
   Alamofire: 2291f7d21ca607c491dd17642e5d40fdcda0e65c
   FSCalendar: ed63fee7df375e34340c1236308fdbfc568d26ac
   Kingfisher: f5d8d60a0ef3edd642fd781bae60918599901aff
+  MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
 
-PODFILE CHECKSUM: 7e5ab95ff915890445e2ab89f00d4d8b8873b433
+PODFILE CHECKSUM: 1d9ca91edc07c4aaced2d67f6c826deae6af278e
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.0


### PR DESCRIPTION
## 🌴 PR 요약
메인에서 탭바 컨트롤러로 화면 전환 시 데이터 전달

🌱 작업한 브랜치
- feature/#97

🌱 작업한 내용
- 메인 뷰 컨트롤러 레이아웃 제약 이슈 있는 부분 해결
- 메인에서 화면 전환 연결 안 되어 있는 부분 연결
- 상단 뷰로 데이터 전달

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src="https://user-images.githubusercontent.com/61109660/125584930-ac49abfc-6337-411a-9340-be020d69366f.gif" width="250" />|

## 📮 관련 이슈
- Resolved: #97 