### PR TITLE
[FEAT] #113 - 일정 삭제 API 연결

### DIFF
--- a/DooRiBon/DooRiBon/Sources/Base/Plan/Models/ScheduleDataModel.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/Models/ScheduleDataModel.swift
@@ -15,6 +15,13 @@ struct ScheduleResponse: Codable {
     let data: ScheduleData?
 }
 
+struct ScheduleResponseAfterDelete: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: [Schedule]?
+}
+
 // MARK: - ScheduleData
 struct ScheduleData: Codable {
     let id: String

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
@@ -101,11 +101,9 @@ extension PlanViewController {
     }
     
     @objc func profileButtonClicked(_ sender: UIButton) {
-        print("profile button clicked")
     }
     
     @objc func settingButtonClicked(_ sender: UIButton) {
-        print("setting button clicked")
     }
     
     @objc func memberButtonClicked(_ sender: UIButton) {
@@ -163,13 +161,11 @@ extension PlanViewController {
     
     private func getSchduleData(date: String) {
         guard let groupId = tripData?._id else { return }
-        print(groupId)
         
         TripPlanDataService.shared.getTripPlan(groupId: groupId,
                                                date: date) { [weak self] (response) in
             switch response {
             case .success(let data):
-                print("success", data)
                 if let schedule = data as? [Schedule] {
                     self!.planDummyData = schedule
                 }
@@ -209,9 +205,43 @@ extension PlanViewController {
                                    memo: scheduleData.memo)
                         .present { event in
                             if event == .edit {
+                                
                             } else {
+                                PopupView.loadFromXib()
+                                    .setTitle("정말 삭제하시겠습니까?")
+                                    .setDescription("한번 삭제한 항목은 다시 되돌릴 수 없습니다.\n그래도 삭제를 원하신다면 오른쪽 버튼을 눌러주세요")
+                                    .setCancelButton()
+                                    .setConfirmButton()
+                                    .present { event in
+                                        if event == .confirm {
+                                            self.deleteSchedule(groupId: groupId, scheduleId: scheduleId)
+                                        } else {
+                                        }
+                                    }
                             }
                         }
+                }
+            case .requestErr(_):
+                print("requestErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            case .pathErr:
+                print("pathErr")
+            }
+        }
+    }
+    
+    private func deleteSchedule(groupId: String, scheduleId: String) {
+        ScheduleDataService.shared.deleteSchedule(groupId: groupId,
+                                               scheduleId: scheduleId) { response in
+            switch response {
+            
+            case .success(let data):
+                if let scheduleData = data as? [Schedule] {
+                    self.getSchduleData(date: "2021-07-15")
+                    self.contentsTableView.reloadData()
                 }
             case .requestErr(_):
                 print("requestErr")
@@ -338,8 +368,6 @@ extension PlanViewController: UICollectionViewDelegateFlowLayout {
 
 extension PlanViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        print("\(indexPath.row)번째 셀클릭")
-        print(111111, planDummyData[indexPath.row].id)
         getScheduleData(groupId: tripData?._id ?? "", scheduleId: planDummyData[indexPath.row].id)
     }
 }

--- a/DooRiBon/DooRiBon/Sources/Base/Plan/Service/ScheduleDataService.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/Service/ScheduleDataService.swift
@@ -36,7 +36,7 @@ struct ScheduleDataService {
             case .success:
                 guard let statusCode = response.response?.statusCode else { return }
                 guard let data = response.value else { return }
-                completion(judgeStatus(status: statusCode, data: data))
+                completion(judgeGetStatus(status: statusCode, data: data))
                 
             case .failure(let err):
                 print(err)
@@ -45,11 +45,49 @@ struct ScheduleDataService {
         }
     }
     
+    // MARK: - Delete Function
+    
+    func deleteSchedule(groupId: String, scheduleId: String, completion: @escaping (NetworkResult<Any>)->()) {
+        let url = makeURL(groupId: groupId, scheduleId: scheduleId)
+        let headers: HTTPHeaders = NetworkInfo.headerWithToken
+        
+        let dataRequest = AF.request(url,
+                                     method: .delete,
+                                     encoding: JSONEncoding.default,
+                                     headers: headers)
+        
+        dataRequest.responseData { (response) in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.value else { return }
+                completion(judgeDeleteStatus(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+                completion(.networkFail)
+            }
+        }
+    }
+    
+    
     // MARK: - Judge Status
     
-    private func judgeStatus(status: Int, data: Data) -> NetworkResult<Any> {
+    private func judgeGetStatus(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(ScheduleResponse.self, from: data) else {return .pathErr}
+        
+        switch status {
+        case 200: return .success(decodedData.data as Any)
+        case 400..<500: return .requestErr(decodedData)
+        case 500: return .serverErr
+        default: return .networkFail
+        }
+    }
+    
+    private func judgeDeleteStatus(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(ScheduleResponseAfterDelete.self, from: data) else {return .pathErr}
         
         switch status {
         case 200: return .success(decodedData.data as Any)

--- a/DooRiBon/DooRiBon/Sources/Common/BottomSheet/BottomSheetView.swift
+++ b/DooRiBon/DooRiBon/Sources/Common/BottomSheet/BottomSheetView.swift
@@ -107,7 +107,7 @@ class BottomSheetView: UIView {
 
     private func closeView(_ type: EventType) {
         eventHandler?(type)
-        moveOut()
+        if type == .edit { moveOut() }
     }
 
     private func moveOut() {

--- a/DooRiBon/DooRiBon/Sources/Common/BottomSheet/BottomSheetView.xib
+++ b/DooRiBon/DooRiBon/Sources/Common/BottomSheet/BottomSheetView.xib
@@ -78,19 +78,19 @@
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여행목표" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s1G-TC-R0S">
-                            <rect key="frame" x="145.33333333333334" y="30.333333333333375" width="34.666666666666657" height="11.666666666666668"/>
+                            <rect key="frame" x="148.66666666666666" y="29.666666666666632" width="37" height="12.666666666666668"/>
                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="10"/>
                             <color key="textColor" name="gray5"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="김민영님이 작성" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CAu-cG-lZF">
-                            <rect key="frame" x="51" y="30.333333333333375" width="63.333333333333343" height="11.666666666666668"/>
+                            <rect key="frame" x="51.000000000000007" y="29.666666666666632" width="66.666666666666686" height="12.666666666666668"/>
                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="10"/>
                             <color key="textColor" name="gray5"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FPn-0g-xXw">
-                            <rect key="frame" x="129.33333333333334" y="29" width="1" height="14"/>
+                            <rect key="frame" x="132.66666666666666" y="29" width="1" height="14"/>
                             <color key="backgroundColor" name="gray6"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="1" id="HQ8-EG-586"/>
@@ -98,19 +98,19 @@
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="인생 사진 찍어오기!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kcz-R5-iVZ">
-                            <rect key="frame" x="26" y="65" width="360" height="24.333333333333329"/>
+                            <rect key="frame" x="26" y="65" width="360" height="20.333333333333329"/>
                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="16"/>
                             <color key="textColor" name="black1"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="i8G-GJ-5dU">
-                            <rect key="frame" x="26" y="104.33333333333337" width="370" height="48"/>
+                            <rect key="frame" x="26" y="100.33333333333337" width="370" height="52"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Xgs-2a-CZl">
-                                    <rect key="frame" x="0.0" y="0.0" width="370" height="14"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="370" height="15.333333333333334"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BBf-Jq-g5v">
-                                            <rect key="frame" x="0.0" y="0.0" width="23" height="14"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="23" height="15.333333333333334"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="23" id="bZ4-U0-7BP"/>
                                             </constraints>
@@ -119,7 +119,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gsy-KM-hxV">
-                                            <rect key="frame" x="31" y="0.0" width="339" height="14"/>
+                                            <rect key="frame" x="31" y="0.0" width="339" height="15.333333333333334"/>
                                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                             <color key="textColor" name="pointBlue"/>
                                             <nil key="highlightedColor"/>
@@ -127,10 +127,10 @@
                                     </subviews>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="7vY-k9-CNo">
-                                    <rect key="frame" x="0.0" y="17" width="370" height="14"/>
+                                    <rect key="frame" x="0.0" y="18.333333333333258" width="370" height="15.333333333333336"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="장소" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wHF-y7-RIS">
-                                            <rect key="frame" x="0.0" y="0.0" width="23" height="14"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="23" height="15.333333333333334"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="23" id="j46-EC-zcp"/>
                                             </constraints>
@@ -139,7 +139,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FDf-nF-FsO">
-                                            <rect key="frame" x="31" y="0.0" width="339" height="14"/>
+                                            <rect key="frame" x="31" y="0.0" width="339" height="15.333333333333334"/>
                                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                             <color key="textColor" name="pointBlue"/>
                                             <nil key="highlightedColor"/>
@@ -147,10 +147,10 @@
                                     </subviews>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="11s-Cl-NGY">
-                                    <rect key="frame" x="0.0" y="34" width="370" height="14"/>
+                                    <rect key="frame" x="0.0" y="36.666666666666629" width="370" height="15.333333333333336"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="메모" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xIE-u9-bdn">
-                                            <rect key="frame" x="0.0" y="0.0" width="23" height="14"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="23" height="15.333333333333334"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="23" id="TQu-NO-SA8"/>
                                             </constraints>
@@ -159,7 +159,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NuL-JU-LQK">
-                                            <rect key="frame" x="31" y="0.0" width="339" height="14"/>
+                                            <rect key="frame" x="31" y="0.0" width="339" height="15.333333333333334"/>
                                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                             <color key="textColor" name="pointBlue"/>
                                             <nil key="highlightedColor"/>


### PR DESCRIPTION
## 🌴 PR 요약
일정 삭제 API를 연결하였습니다.

🌱 작업한 브랜치
- feature/#113

🌱 작업한 내용
- 데이터 모델 일부 추가
- 서비스 코드 작성
- 삭제 API 연결
- 삭제 후 테이블뷰 리로드

### 🚨 이슈
일정 삭제를 마치고 난 다음에 바텀시트도 같이 dismiss 되어야 하는데 유지되는 이슈 존재

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![Simulator Screen Recording - iPhone 11 Pro - 2021-07-15 at 14 19 22](https://user-images.githubusercontent.com/61109660/125733040-d618f504-88b0-4f14-8a0d-921f659dcc45.gif)|

## 📮 관련 이슈
- Resolved: #113