### PR TITLE
[FEAT] #115 - 여행 보드 삭제 API 연결

### DIFF
--- a/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
+++ b/DooRiBon/DooRiBon.xcodeproj/project.pbxproj
@@ -102,7 +102,7 @@
 		BD5EEC9426986AB100D09B11 /* BoardNoDataTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5EEC9226986AB100D09B11 /* BoardNoDataTableViewCell.swift */; };
 		BD5EEC9526986AB100D09B11 /* BoardNoDataTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD5EEC9326986AB100D09B11 /* BoardNoDataTableViewCell.xib */; };
 		BD6074B5269DF8AD00CA62F3 /* AddBoardRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6074B4269DF8AD00CA62F3 /* AddBoardRequest.swift */; };
-		BD6074B7269DF92700CA62F3 /* AddBoardResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6074B6269DF92700CA62F3 /* AddBoardResponse.swift */; };
+		BD6074B7269DF92700CA62F3 /* BoardResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6074B6269DF92700CA62F3 /* BoardResponse.swift */; };
 		BD6074BA269DFA0200CA62F3 /* AddBoardDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6074B9269DFA0200CA62F3 /* AddBoardDataService.swift */; };
 		BD6074BC269E015E00CA62F3 /* BoardSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6074BB269E015E00CA62F3 /* BoardSectionHeaderView.swift */; };
 		BD6074C0269E019C00CA62F3 /* BoardSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD6074BF269E019C00CA62F3 /* BoardSectionHeaderView.xib */; };
@@ -238,7 +238,7 @@
 		BD5EEC9226986AB100D09B11 /* BoardNoDataTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardNoDataTableViewCell.swift; sourceTree = "<group>"; };
 		BD5EEC9326986AB100D09B11 /* BoardNoDataTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BoardNoDataTableViewCell.xib; sourceTree = "<group>"; };
 		BD6074B4269DF8AD00CA62F3 /* AddBoardRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBoardRequest.swift; sourceTree = "<group>"; };
-		BD6074B6269DF92700CA62F3 /* AddBoardResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBoardResponse.swift; sourceTree = "<group>"; };
+		BD6074B6269DF92700CA62F3 /* BoardResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardResponse.swift; sourceTree = "<group>"; };
 		BD6074B9269DFA0200CA62F3 /* AddBoardDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBoardDataService.swift; sourceTree = "<group>"; };
 		BD6074BB269E015E00CA62F3 /* BoardSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSectionHeaderView.swift; sourceTree = "<group>"; };
 		BD6074BF269E019C00CA62F3 /* BoardSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BoardSectionHeaderView.xib; sourceTree = "<group>"; };
@@ -930,7 +930,7 @@
 			children = (
 				BDA5626826994E2000616CBF /* DummyDataModel.swift */,
 				BD6074B4269DF8AD00CA62F3 /* AddBoardRequest.swift */,
-				BD6074B6269DF92700CA62F3 /* AddBoardResponse.swift */,
+				BD6074B6269DF92700CA62F3 /* BoardResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1207,7 +1207,7 @@
 				BDA5626C2699962B00616CBF /* BoardTableViewCell.swift in Sources */,
 				4096A977269D6D0000EBDE56 /* AddTripService.swift in Sources */,
 				BD75C300268B5BA800C4F233 /* UIFont+Extension.swift in Sources */,
-				BD6074B7269DF92700CA62F3 /* AddBoardResponse.swift in Sources */,
+				BD6074B7269DF92700CA62F3 /* BoardResponse.swift in Sources */,
 				BD5EEC9426986AB100D09B11 /* BoardNoDataTableViewCell.swift in Sources */,
 				40A0EA42269C4596009EDE74 /* NibConstants.swift in Sources */,
 				392EF95126918450008CA532 /* ComeTripCollectionViewCell.swift in Sources */,

--- a/DooRiBon/DooRiBon/Resources/Network/APIConstants.swift
+++ b/DooRiBon/DooRiBon/Resources/Network/APIConstants.swift
@@ -45,6 +45,7 @@ struct APIConstants {
     static let getScheduleURL = baseURL + "/schedule/:groupId/:scheduleId"
     
     // MARK: - /board
+    static let boardURL = baseURL + "/board"
     static let postBoardURL = baseURL + "/board/:groupId/:tag"          // 여행 보드 추가
     
     // MARK: - /tendency

--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardStoryboard.storyboard
@@ -198,7 +198,7 @@
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="Vc2-ur-S1c"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="YCS-k1-Rpy">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelectionDuringEditing="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="YCS-k1-Rpy">
                                 <rect key="frame" x="0.0" y="275" width="375" height="454"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -227,7 +227,7 @@
                     </tabBarItem>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="tableView" destination="YCS-k1-Rpy" id="XdP-c9-1GN"/>
+                        <outlet property="boardTableView" destination="YCS-k1-Rpy" id="XdP-c9-1GN"/>
                         <outlet property="topView" destination="gyK-uK-iJ4" id="iRZ-b2-dhh"/>
                         <outletCollection property="iconImageView" destination="5oc-D0-hsE" collectionClass="NSMutableArray" id="CmF-zv-47g"/>
                         <outletCollection property="iconImageView" destination="xpx-0U-fxz" collectionClass="NSMutableArray" id="uu6-18-dqX"/>

--- a/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/BoardViewController.swift
@@ -70,7 +70,7 @@ class BoardViewController: UIViewController {
         }
     }
     
-    private var currentBoardData: [AddBoardData]? {
+    private var currentBoardData: [BoardData]? {
         didSet {
             tableView.reloadData()
         }
@@ -81,7 +81,7 @@ class BoardViewController: UIViewController {
     private var contents: String = ""
     
     static var profileData: [Profile] = []
-    static var thisID: String = ""
+    private var thisID: String = ""
     
     // MARK: - Life Cycle
     
@@ -96,13 +96,13 @@ class BoardViewController: UIViewController {
         super.viewWillAppear(animated)
         setupTopView()
         guard let tag = Tag(rawValue: selectedTagIndex)?.description else { return }
-        getBoardData(tag: tag)
+        getBoardData(groupId: self.thisID, tag: tag)
     }
     
-    private func postTripBoard(contents: String, tag: String) {
+    private func postTripBoard(contents: String, groupId: String, tag: String) {
         let input = AddBoardRequest(content: contents)
         AddBoardDataService.shared.postTripBoard(input,
-                                                 groupId: "60ed24ad317c7b2480ee1ec6",
+                                                 groupId: groupId,
                                                  tag: tag) { response in
             switch(response)
             {
@@ -120,13 +120,15 @@ class BoardViewController: UIViewController {
         }
     }
     
-    private func getBoardData(tag: String) {
-        AddBoardDataService.shared.getTripBoard(groupId: "60ed24ad317c7b2480ee1ec6",
+    private func getBoardData(groupId: String, tag: String) {
+        AddBoardDataService.shared.getTripBoard(groupId: groupId,
                                                 tag: tag) { response in
+            
+            
             switch(response)
             {
             case .success(let data) :
-                if let data = data as? [AddBoardData] {
+                if let data = data as? [BoardData] {
                     self.currentBoardData = data
                 }
 
@@ -149,7 +151,7 @@ extension BoardViewController {
     private func setupTopView() {
         guard let model = (self.tabBarController as! TripViewController).tripData else { return }
         topView.setTopViewData(tripData: model)
-        MemberViewController.thisID = model._id
+        self.thisID = model._id
     }
     
     private func setupUI() {
@@ -190,7 +192,7 @@ extension BoardViewController {
             .setTitle("함께하는 사람")
             .setDescription("총 5명")
             .setConfirmButton("참여코드 복사하기")
-            .setGroupId(id: MemberViewController.thisID)
+            .setGroupId(id: self.thisID)
             .present { event in
                  if event == .confirm {
                     ToastView.show("참여코드 복사 완료! 원하는 곳에 붙여넣기 하세요.")
@@ -238,7 +240,7 @@ extension BoardViewController {
         selectedTagIndex = sender.tag
         
         guard let tag = Tag(rawValue: selectedTagIndex)?.description else { return }
-        getBoardData(tag: tag)
+        getBoardData(groupId: self.thisID, tag: tag)
         
         tableView.reloadData()
     }
@@ -278,8 +280,8 @@ extension BoardViewController: UITableViewDelegate, BoardSectionHeaderViewDelega
             .setDescription(popupData[selectedTagIndex].description)
             .present { event in
                 if event == .confirm {
-                    self.postTripBoard(contents: self.contents, tag: description)
-                    self.getBoardData(tag: description)
+                    self.postTripBoard(contents: self.contents, groupId: self.thisID, tag: description)
+                    self.getBoardData(groupId: self.thisID, tag: description)
                     self.tableView.reloadData()
                 }
             }

--- a/DooRiBon/DooRiBon/Sources/Base/Board/Models/BoardResponse.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/Models/BoardResponse.swift
@@ -12,15 +12,15 @@
 import Foundation
 
 // MARK: - AddBoardResponse
-struct AddBoardResponse: Codable {
+struct BoardResponse: Codable {
     let status: Int
     let success: Bool
     let message: String
-    let data: [AddBoardData]?       // data는 실패하면 들어오지 않기 때문에 옵셔널 형태로 선언
+    let data: [BoardData]?       // data는 실패하면 들어오지 않기 때문에 옵셔널 형태로 선언
 }
 
 // MARK: - AddBoardData
-struct AddBoardData: Codable {
+struct BoardData: Codable {
     let id, name, content: String
 
     enum CodingKeys: String, CodingKey {

--- a/DooRiBon/DooRiBon/Sources/Base/Board/Services/AddBoardDataService.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/Services/AddBoardDataService.swift
@@ -77,7 +77,7 @@ struct AddBoardDataService {
     
     private func judgeStatus(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(AddBoardResponse.self, from: data) else {return .pathErr}
+        guard let decodedData = try? decoder.decode(BoardResponse.self, from: data) else {return .pathErr}
         
         switch status {
         case 200: return .success(decodedData.data as Any)

--- a/DooRiBon/DooRiBon/Sources/Base/Board/Services/AddBoardDataService.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Board/Services/AddBoardDataService.swift
@@ -22,6 +22,11 @@ struct AddBoardDataService {
         return url
     }
     
+    private func makeDeleteURL(groupId: String, tag: String, boardId: String) -> String {
+        let url = APIConstants.boardURL + "/\(groupId)" + "/\(tag)" + "/\(boardId)"
+        return url
+    }
+    
     // MARK: - Get Function
     
     func getTripBoard(groupId: String, tag: String, completion: @escaping (NetworkResult<Any>)->()) {
@@ -72,6 +77,32 @@ struct AddBoardDataService {
             }
         }
     }
+    
+    // MARK: - Delete Function
+    
+    func deleteTripBoard(groupId: String, tag: String, boardId: String, completion: @escaping (NetworkResult<Any>)->()) {
+        let url = makeDeleteURL(groupId: groupId, tag: tag, boardId: boardId)
+        let headers: HTTPHeaders = NetworkInfo.headerWithToken
+        
+        let dataRequest = AF.request(url,
+                                     method: .delete,
+                                     encoding: JSONEncoding.default,
+                                     headers: headers)
+        
+        dataRequest.responseData { (response) in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.value else { return }
+                completion(judgeStatus(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+                completion(.networkFail)
+            }
+        }
+    }
+    
     
     // MARK: - Judge Status
     


### PR DESCRIPTION
## 🌴 PR 요약
여행 보드 삭제 API를 연결했습니다.

🌱 작업한 브랜치
- feature/#115

🌱 작업한 내용
- API Constants 추가
- 서비스 코드 추가
- 보드 삭제 API 연결

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![Simulator Screen Recording - iPhone 11 Pro - 2021-07-15 at 15 26 21](https://user-images.githubusercontent.com/61109660/125739751-bbef645c-1549-4887-9ba1-85876b6cfe85.gif)|

## 📮 관련 이슈
- Resolved: #115