### PR TITLE
[FIX] #175 - 여행 추가 화면 이슈 수정

### DIFF
--- a/DooRiBon/DooRiBon/Sources/Main/AddTrip/AddTripStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Main/AddTrip/AddTripStoryboard.storyboard
@@ -423,6 +423,7 @@
                     <size key="freeformSize" width="375" height="1031"/>
                     <connections>
                         <outlet property="bottomView" destination="ek5-dk-28i" id="G3w-8D-dFW"/>
+                        <outlet property="collectionViewHeightConstraint" destination="7iG-tC-LGs" id="hMR-gU-m8Y"/>
                         <outlet property="endDateLabel" destination="X72-D0-O1m" id="I60-f5-lDM"/>
                         <outlet property="endDateView" destination="7zo-4U-PtA" id="AJS-dV-zN5"/>
                         <outlet property="mainView" destination="gBc-aY-KFV" id="3Oo-qd-QGc"/>

--- a/DooRiBon/DooRiBon/Sources/Main/AddTrip/AddTripViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/AddTrip/AddTripViewController.swift
@@ -31,6 +31,8 @@ class AddTripViewController: UIViewController {
     @IBOutlet weak var endDateView: UIView!
     @IBOutlet weak var bottomView: UIView!
     @IBOutlet weak var mainView: UIView!
+
+    @IBOutlet weak var collectionViewHeightConstraint: NSLayoutConstraint!
     
     //MARK:- Variable
     
@@ -56,11 +58,18 @@ class AddTripViewController: UIViewController {
         registerForKeyboardNotifications()
         
         scrollView.keyboardDismissMode = .onDrag
+        photoCollectionView.isScrollEnabled = false
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        collectionViewHeightConstraint.constant = photoCollectionView.collectionViewLayout.collectionViewContentSize.height
+        view.layoutIfNeeded()
     }
     
     //MARK:- IBAction

--- a/DooRiBon/DooRiBon/Sources/Main/AddTrip/Cells/PhotoCollectionViewCell.swift
+++ b/DooRiBon/DooRiBon/Sources/Main/AddTrip/Cells/PhotoCollectionViewCell.swift
@@ -32,7 +32,7 @@ class PhotoCollectionViewCell: UICollectionViewCell {
         didSet {
             if isSelected && !selectCheck {
                 checkImage.isHidden = false
-                shadeView.alpha = 0.7
+                shadeView.alpha = 1
                 selectCheck = true
             } else if isSelected && selectCheck {
                 checkImage.isHidden = true
@@ -44,10 +44,6 @@ class PhotoCollectionViewCell: UICollectionViewCell {
                 selectCheck = false
             }
         }
-    }
-    
-    override func prepareForReuse() {
-        
     }
     
     //MARK:- Function

--- a/DooRiBon/DooRiBon/Sources/Main/AddTrip/Cells/PhotoCollectionViewCell.xib
+++ b/DooRiBon/DooRiBon/Sources/Main/AddTrip/Cells/PhotoCollectionViewCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,35 +25,39 @@
                                 <real key="value" value="0.0"/>
                             </userDefinedRuntimeAttribute>
                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                <real key="value" value="5"/>
+                                <real key="value" value="10"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ui1-eH-aCQ">
                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                <real key="value" value="15"/>
+                                <real key="value" value="10"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                <real key="value" value="2"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                <color key="value" name="pointBlue"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </view>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconCheck" translatesAutoresizingMaskIntoConstraints="NO" id="IQq-Ag-PPH">
-                        <rect key="frame" x="20" y="20" width="10" height="10"/>
+                        <rect key="frame" x="9.5" y="9.5" width="31" height="31"/>
                     </imageView>
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
-                <constraint firstItem="IQq-Ag-PPH" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="1ul-hP-0En"/>
-                <constraint firstItem="IQq-Ag-PPH" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="20" id="5Cq-yr-now"/>
                 <constraint firstItem="8MB-1K-cRq" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="BcH-k1-QPY"/>
                 <constraint firstAttribute="bottom" secondItem="ui1-eH-aCQ" secondAttribute="bottom" id="E0n-CK-53Y"/>
-                <constraint firstAttribute="trailing" secondItem="IQq-Ag-PPH" secondAttribute="trailing" constant="20" id="Tfn-jr-mAT"/>
+                <constraint firstItem="IQq-Ag-PPH" firstAttribute="centerX" secondItem="ui1-eH-aCQ" secondAttribute="centerX" id="EyQ-ip-OI9"/>
+                <constraint firstItem="IQq-Ag-PPH" firstAttribute="centerY" secondItem="ui1-eH-aCQ" secondAttribute="centerY" id="Lzs-3z-Vh1"/>
                 <constraint firstItem="8MB-1K-cRq" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="Xd9-FI-bCw"/>
                 <constraint firstItem="ui1-eH-aCQ" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="eQQ-a0-WzF"/>
                 <constraint firstItem="ui1-eH-aCQ" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="fi1-3F-QTR"/>
-                <constraint firstAttribute="bottom" secondItem="IQq-Ag-PPH" secondAttribute="bottom" constant="20" id="g5c-Lb-bUG"/>
                 <constraint firstAttribute="bottom" secondItem="8MB-1K-cRq" secondAttribute="bottom" id="mSp-TM-BEm"/>
                 <constraint firstAttribute="trailing" secondItem="8MB-1K-cRq" secondAttribute="trailing" id="mbI-TE-q57"/>
                 <constraint firstAttribute="trailing" secondItem="ui1-eH-aCQ" secondAttribute="trailing" id="zrK-xG-W5W"/>
@@ -67,5 +72,8 @@
     </objects>
     <resources>
         <image name="iconCheck" width="31" height="31"/>
+        <namedColor name="pointBlue">
+            <color red="0.41999998688697815" green="0.56099998950958252" blue="0.97600001096725464" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
## 🌴 PR 요약
- 여행 추가 화면의 사진 collectionView 높이를 동적으로 수정
- 이미지 선택시 UI 변경
- 이미지 안의 체크 이미지 크기 조정(크기 바뀌지 않도록 가운데 정렬만)

🌱 작업한 브랜치
- BUG/#175

🌱 작업한 내용
- 여행 추가 화면의 사진 collectionView 높이를 동적으로 수정
- 이미지 선택시 UI 변경

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF| <img src="https://user-images.githubusercontent.com/22652499/125994480-5c490d55-e0f0-4170-9355-03603959b91c.gif" width=250\> |

## 📮 관련 이슈
- Resolved: #175