### PR TITLE
[FEAT] #180 - 자세히 보기 버튼 클릭 구현

### DIFF
--- a/DooRiBon/DooRiBon/Sources/Base/Member/MemberOur/Cell/MemberOurTableViewCell.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Member/MemberOur/Cell/MemberOurTableViewCell.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol MemberTableCellDelegate: AnyObject {
+    func didDetailLookButtonTapppd(for cell: MemberOurTableViewCell)
+}
+
 class MemberOurTableViewCell: UITableViewCell {
 
     @IBOutlet weak var memberOurBackgroundView: UIView!
@@ -17,11 +21,12 @@ class MemberOurTableViewCell: UITableViewCell {
     @IBOutlet weak var memberName: UILabel!
     @IBOutlet weak var memberThumbNailImage: UIImageView!
     
+    var delegate: MemberTableCellDelegate?
+    var indexPath: IndexPath?
     
     override func awakeFromNib() {
         super.awakeFromNib()
         cellShadowSet()
-        // Initialization code
     }
     
     private func cellShadowSet() {
@@ -29,4 +34,7 @@ class MemberOurTableViewCell: UITableViewCell {
         memberOurBackgroundView.layer.applyShadow(color: .black, alpha: 0.07, x: 0, y: 3, blur: 10, spread: 0)
     }
 
+    @IBAction func detailLookButtonTapped(_ sender: Any) {
+        delegate?.didDetailLookButtonTapppd(for: self)
+    }
 }

--- a/DooRiBon/DooRiBon/Sources/Base/Member/MemberOur/MemberOurStoryboard.storyboard
+++ b/DooRiBon/DooRiBon/Sources/Base/Member/MemberOur/MemberOurStoryboard.storyboard
@@ -47,8 +47,8 @@
                                                                 <constraint firstAttribute="height" constant="113" id="t2i-nm-uLh"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jlw-7S-Hdm">
-                                                            <rect key="frame" x="239" y="73" width="126" height="24"/>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jlw-7S-Hdm">
+                                                            <rect key="frame" x="239" y="74" width="126" height="24"/>
                                                             <color key="backgroundColor" name="pointOrange"/>
                                                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                                                             <state key="normal" title="자세히보기 &gt;">
@@ -59,9 +59,12 @@
                                                                     <real key="value" value="12"/>
                                                                 </userDefinedRuntimeAttribute>
                                                             </userDefinedRuntimeAttributes>
+                                                            <connections>
+                                                                <action selector="detailLookButtonTapped:" destination="eKD-T5-ATp" eventType="touchUpInside" id="bEl-kI-zYs"/>
+                                                            </connections>
                                                         </button>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6TZ-Ko-xxC">
-                                                            <rect key="frame" x="14" y="11" width="33" height="18"/>
+                                                            <rect key="frame" x="14" y="11" width="29.5" height="16.5"/>
                                                             <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="14"/>
                                                             <color key="textColor" name="black3"/>
                                                             <nil key="highlightedColor"/>
@@ -76,10 +79,10 @@
                                                             <rect key="frame" x="14" y="72" width="20" height="20"/>
                                                         </imageView>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CRt-Tl-24X">
-                                                            <rect key="frame" x="15" y="41" width="44" height="22"/>
+                                                            <rect key="frame" x="15" y="39.5" width="42.5" height="22"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="style1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9V-81-VkT">
-                                                                    <rect key="frame" x="8" y="4" width="28" height="14"/>
+                                                                    <rect key="frame" x="8" y="4" width="26.5" height="14"/>
                                                                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="10"/>
                                                                     <color key="textColor" name="gray10"/>
                                                                     <nil key="highlightedColor"/>
@@ -106,10 +109,10 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="llg-KB-Si3">
-                                                            <rect key="frame" x="64" y="41" width="44" height="21"/>
+                                                            <rect key="frame" x="62.5" y="39.5" width="42.5" height="21"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="style2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WkQ-Ws-NCV">
-                                                                    <rect key="frame" x="8" y="4" width="28" height="13"/>
+                                                                    <rect key="frame" x="8" y="4" width="26.5" height="13"/>
                                                                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="10"/>
                                                                     <color key="textColor" name="gray10"/>
                                                                     <nil key="highlightedColor"/>
@@ -135,10 +138,10 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TUf-dS-PIQ">
-                                                            <rect key="frame" x="113" y="41" width="44" height="21"/>
+                                                            <rect key="frame" x="110" y="39.5" width="42.5" height="21"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="style3" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yEI-ga-sQY">
-                                                                    <rect key="frame" x="8" y="4" width="28" height="13"/>
+                                                                    <rect key="frame" x="8" y="4" width="26.5" height="13"/>
                                                                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="10"/>
                                                                     <color key="textColor" name="gray10"/>
                                                                     <nil key="highlightedColor"/>

--- a/DooRiBon/DooRiBon/Sources/Base/Member/MemberOur/MemberOurViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Member/MemberOur/MemberOurViewController.swift
@@ -70,7 +70,34 @@ class MemberOurViewController: UIViewController, PageComponentProtocol {
 
 //MARK:- Extension
 
-extension MemberOurViewController: UITableViewDelegate, UITableViewDataSource {
+extension MemberOurViewController: UITableViewDelegate, UITableViewDataSource, MemberTableCellDelegate {
+    func didDetailLookButtonTapppd(for cell: MemberOurTableViewCell) {
+        let indexPath = cell.indexPath
+        if indexPath?.section == 0 {
+            if myStyleData != nil {
+                let testReusltStoryboard = UIStoryboard(name: "StyleTestResultStoryboard", bundle: nil)
+                guard let nextVC = testReusltStoryboard.instantiateViewController(identifier: "StyleTestResultViewController") as? StyleTestResultViewController else { return }
+                nextVC.name = myStyleData?.member.name ?? ""
+                nextVC.imgURL = myStyleData?.iOSResultImage ?? ""
+                nextVC.style = myStyleData?.title ?? ""
+                nextVC.fromOurView = true
+                nextVC.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(nextVC, animated: true)
+            }
+        } else {
+            if memberStyleData.count != 0 {
+                let testReusltStoryboard = UIStoryboard(name: "StyleTestResultStoryboard", bundle: nil)
+                guard let nextVC = testReusltStoryboard.instantiateViewController(identifier: "StyleTestResultViewController") as? StyleTestResultViewController else { return }
+                nextVC.name = memberStyleData[indexPath?.row ?? 0].member.name
+                nextVC.imgURL = memberStyleData[indexPath?.row ?? 0].iOSResultImage
+                nextVC.style = memberStyleData[indexPath?.row ?? 0].title
+                nextVC.fromOurView = true
+                nextVC.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(nextVC, animated: true)
+            }
+        }
+    }
+
     func numberOfSections(in tableView: UITableView) -> Int {
         return 2
     }
@@ -142,6 +169,8 @@ extension MemberOurViewController: UITableViewDelegate, UITableViewDataSource {
                 cell.memberStyleThree.text = myStyleData?.tag[2]
                 cell.memberThumbNailImage.kf.setImage(with: URL(string: myStyleData?.thumbnail ?? ""))
                 cell.selectionStyle = .none
+                cell.delegate = self
+                cell.indexPath = indexPath
                 return cell
             } else {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "MemberStartTableViewCell", for: indexPath) as? MemberStartTableViewCell else { return UITableViewCell() }
@@ -158,6 +187,8 @@ extension MemberOurViewController: UITableViewDelegate, UITableViewDataSource {
                 cell.memberStyleThree.text = memberStyleData[indexPath.row].tag[2]
                 cell.memberThumbNailImage.kf.setImage(with: URL(string: memberStyleData[indexPath.row].thumbnail))
                 cell.selectionStyle = .none
+                cell.delegate = self
+                cell.indexPath = indexPath
                 return cell
             } else {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "MemberCodeCopyTableViewCell", for: indexPath) as? MemberCodeCopyTableViewCell else { return UITableViewCell() }
@@ -205,6 +236,11 @@ extension MemberOurViewController: goToTestViewProtocol {
     }
 }
 extension MemberOurViewController {
+    enum UserState {
+        case my
+        case you
+    }
+    
     private func setupFirstData() {
         guard let model = (self.tabBarController as! TripViewController).tripData else { return }
         tripData = model


### PR DESCRIPTION
## 🌴 PR 요약
기존에 여행 성향 뷰에서 자세히 보기 버튼 눌렀을 때 액션이 안 되는 이슈를 해결했습니다.

🌱 작업한 브랜치
- feature/#180

🌱 작업한 내용
- 자세히 보기 포함 셀 전체 범위에서 클릭가능하도록 변경

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|생략|

## 📮 관련 이슈
- Resolved: #180