### PR TITLE
[BUG] #196 - 일정 뷰 로딩 버그 수정

### DIFF
--- a/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
+++ b/DooRiBon/DooRiBon/Sources/Base/Plan/PlanViewController.swift
@@ -236,9 +236,9 @@ extension PlanViewController {
             switch response {
             case .success(let data):
                 if let schedule = data as? [Schedule] {
-                    self?.endLoading()
                     self!.planData = schedule
                 }
+                self?.endLoading()
             case .requestErr(_):
                 print("requestErr")
                 self?.endLoading()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- bug/196-planLoading

🌱 작업한 내용
- 일정 뷰 로딩 인디케이터 버그 수정 (일정이 비어있을 경우, 무한 로딩이 발생했던 오류)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|생략|

## 📮 관련 이슈
- Resolved: #196